### PR TITLE
data: add missing services detected by scraper (Jan 2026)

### DIFF
--- a/data/regions/azure/azure_canada_east.yaml
+++ b/data/regions/azure/azure_canada_east.yaml
@@ -13,4 +13,6 @@ services:
   vdc_vault:
     - edition: "Foundation"
       tier: "Core"
+    - edition: "Advanced"
+      tier: "Core"
   vdc_azure_backup: true

--- a/data/regions/azure/azure_nz_north.yaml
+++ b/data/regions/azure/azure_nz_north.yaml
@@ -15,3 +15,4 @@ services:
       tier: "Core"
     - edition: "Advanced"
       tier: "Core"
+  vdc_salesforce: true

--- a/data/regions/azure/azure_south_africa_north.yaml
+++ b/data/regions/azure/azure_south_africa_north.yaml
@@ -17,3 +17,4 @@ services:
       tier: "Non-Core"
   vdc_m365: true
   vdc_azure_backup: true
+  vdc_entra_id: true

--- a/data/regions/azure/azure_switzerland_north.yaml
+++ b/data/regions/azure/azure_switzerland_north.yaml
@@ -15,3 +15,4 @@ services:
       tier: "Core"
   vdc_m365: true
   vdc_azure_backup: true
+  vdc_entra_id: true


### PR DESCRIPTION
This PR adds missing services to several Azure regions as detected by the automated region scraper.

### Changes
- Added **VDC for Entra ID** to **South Africa North (Johannesburg)** (Azure)
- Added **VDC for Entra ID** to **Switzerland North (Zurich)** (Azure)
- Added **VDC for Salesforce** to **New Zealand North (Auckland)** (Azure)
- Added **VDC Vault (Advanced Edition, Core Tier)** to **Canada East (Quebec)** (Azure)

Closes #28, #29, #30, #36