### PR TITLE
chore: merge release 1.1.2 version bump back to develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veeam-data-cloud-services-map",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Interactive map and API for Veeam Data Cloud service availability across AWS and Azure regions",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Merges the `chore(release): bump version to 1.1.2` commit from the release branch back into `develop` so the branch stays in sync with `main`.