### PR TITLE
fix(ui): dark mode select, safe area bottom, error copy

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -38,6 +38,7 @@
             flex-direction: column;
             height: 100vh;
             height: 100dvh;
+            padding-bottom: env(safe-area-inset-bottom);
         }
         
         .map-container {
@@ -82,8 +83,14 @@
 
         /* Select dropdown styling */
         select {
+            background-color: #1e293b; /* dark */
+            color: white;
             transition: border-color 0.2s ease;
             cursor: pointer;
+        }
+        .light select {
+            background-color: white;
+            color: #0f172a;
         }
         select:hover {
             border-color: #00d15f !important;
@@ -698,7 +705,7 @@
                 </div>
                 <div>
                     <h3 class="text-lg font-semibold text-white light:text-slate-900 mb-1">Failed to Load Map</h3>
-                    <p class="text-slate-400 light:text-slate-500 text-sm max-w-xs">There was a problem loading the map. Please check your internet connection and try refreshing the page.</p>
+                    <p class="text-slate-400 light:text-slate-500 text-sm max-w-xs">The map failed to load. Please check your internet connection and try refreshing the page.</p>
                 </div>
                 <button onclick="location.reload()" class="px-4 py-2 bg-green-600 hover:bg-green-700 text-white text-sm font-medium rounded-lg transition-colors">
                     Refresh Page


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR changes -->
Added explicit dark mode styles for native <select> (Windows)
Added bottom safe area padding for mobile devices
Updated error message to active voice

## Type of Change

- [ ] Adding a new region
- [ ] Adding a service to an existing region
- [ ] Correcting existing data
- [ X] Other (UI polish / accessibility fixes)

## Regions/Services Affected

<!-- List the regions and/or services being added or modified -->

| Provider | Region | Service(s) |
|----------|--------|------------|
|  N/A        |      N/A  |      N/A      |

## Source / Evidence

<!-- 
Change made according to Issue #82
Tested locally on Mac and Iphone simulator
-->

## Checklist

- [ ] I have verified this information from an official Veeam source
- [ ] Region YAML files follow the correct structure:
  - [ ] `provider` is exactly `"AWS"` or `"Azure"` (case-sensitive)
  - [ ] `coords` is an array `[lat, lon]`, not a string
  - [ ] Tiered services (`vdc_vault`) use array of `{edition, tier}` objects
  - [ ] Boolean services (`vdc_m365`, `vdc_entra_id`, `vdc_salesforce`, `vdc_azure_backup`) are set to `true`
- [X] I have tested locally with `hugo server` (if possible)
- [ ] File naming follows convention: `{provider}_{region_code}.yaml`

## Related Issues

<!-- Closes #82 -->

