### PR TITLE
fix(ui): polish select contrast, mobile safe-area bottom, and error copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2026-03-21
+
+### Added
+- Azure Poland Central (Warsaw) region with VDC for Microsoft 365 and Entra ID support (#74)
+
+### Changed
+- Bump hono from 4.11.7 to 4.12.7 (#72)
+- Bump undici and wrangler to latest versions (#73)
+
+## [1.1.2] - 2025-01-22
+
+### Fixed
+- Add missing VDC for Azure service to NZ North and Austria East regions (#64)
+- Add 8 missing Azure regions for VDC for Azure support (#63)
+- Add missing VDC services to Azure regions (#52)
+
+## [1.1.1] - 2025-01-03
+
+### Added
+- Comprehensive gitflow release guide (`GITFLOW_RELEASE_GUIDE.md`)
+- AWS Taipei region corrected to `ap-east-2` (#45)
+- VDC M365 service added to Azure Korea Central (#43)
+
+### Changed
+- Bump hono from 4.11.4 to 4.11.7 (#41)
+- Bump wrangler from 4.54.0 to 4.59.1 (#39)
+
+## [1.1.0] - 2024-12-29
+
+### Added
+- REST API for programmatic access to service availability data (Hono + Cloudflare Workers)
+- OpenAPI/Scalar interactive API documentation at `/api/docs`
+- `/api/v1/regions/nearest` endpoint to find closest regions by coordinates
+- `/api/v1/regions/compare` endpoint to compare service availability across regions
+- `/api/v1/services/{serviceId}` endpoint with detailed per-service region lists
+- Region data for additional AWS and Azure regions
+- Automated region scraping and validation pipeline
+- LLM-friendly documentation (`static/llms.txt`, `static/llms-full.txt`)
+
+### Changed
+- Migrated deployment to Cloudflare Pages (from GitHub Pages)
+- Region data moved to individual YAML files per region
+
+## [1.0.0] - 2024-12-01
+
+### Added
+- Initial interactive map using Hugo, Leaflet.js, and Tailwind CSS
+- YAML-driven region data for AWS and Azure regions
+- Service filtering by provider, service type, and pricing tier
+- Dark-mode map with CartoDB Dark Matter tiles
+- GitHub Actions CI/CD pipeline
+
+[1.2.0]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.1.2...v1.2.0
+[1.1.2]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/comnam90/veeam-data-cloud-services-map/releases/tag/v1.0.0

--- a/GITFLOW_RELEASE_GUIDE.md
+++ b/GITFLOW_RELEASE_GUIDE.md
@@ -44,12 +44,14 @@ npm run build
 
 The release branch should be merged to `main` via a Pull Request:
 
+> ⚠️ **Important:** When creating the PR, always verify that the **base branch is set to `main`**, not `develop`. GitHub may default to a different base depending on how the branch was created.
+
 ```bash
 # Push release branch
 git push origin release/1.1.1
 
-# Create PR: release/1.1.1 → main
-# Title: "Release v1.1.1"
+# Create PR: release/1.1.1 → main   ← base MUST be main
+# Title: "chore(release): v1.1.1"
 # Include:
 # - List of changes since last release
 # - Version bump details

--- a/GITFLOW_RELEASE_GUIDE.md
+++ b/GITFLOW_RELEASE_GUIDE.md
@@ -189,10 +189,10 @@ Without merging back to develop:
 
 ## Current Release Status
 
-For the v1.1.1 release:
+For the v1.2.0 release:
 
 ✅ **Step 1**: Release branch created from develop
-✅ **Step 2**: Version bumped to 1.1.1  
+✅ **Step 2**: Version bumped to 1.2.0
 ✅ **Step 3**: Ready to merge to main (via current PR)
 ⏳ **Step 4**: After main merge, needs to merge back to develop
 ⏳ **Step 5**: Cleanup release branch

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -36,6 +36,7 @@
         .map-container {
             flex: 1;
             min-height: 0;
+            padding-bottom: env(safe-area-inset-bottom);
         }
         
         #map { 
@@ -75,8 +76,14 @@
 
         /* Select dropdown styling */
         select {
+            background-color: #1e293b;
+            color: #ffffff;
             transition: all 0.2s ease;
             cursor: pointer;
+        }
+        .light select {
+            background-color: #ffffff;
+            color: #0f172a;
         }
         select:hover {
             border-color: #00d15f !important;
@@ -678,7 +685,7 @@
                 </div>
                 <div>
                     <h3 class="text-lg font-semibold text-white light:text-slate-900 mb-1">Failed to Load Map</h3>
-                    <p class="text-slate-400 light:text-slate-500 text-sm max-w-xs">There was a problem loading the map. Please check your internet connection and try refreshing the page.</p>
+                    <p class="text-slate-400 light:text-slate-500 text-sm max-w-xs">The map failed to load. Please check your internet connection and try refreshing the page.</p>
                 </div>
                 <button onclick="location.reload()" class="px-4 py-2 bg-green-600 hover:bg-green-700 text-white text-sm font-medium rounded-lg transition-colors">
                     Refresh Page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veeam-data-cloud-services-map",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Interactive map and API for Veeam Data Cloud service availability across AWS and Azure regions",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veeam-data-cloud-services-map",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Interactive map and API for Veeam Data Cloud service availability across AWS and Azure regions",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- add explicit dark/light colors for native `select` controls to improve Windows dark mode readability
- add `padding-bottom: env(safe-area-inset-bottom)` to `.map-container` so content isn’t clipped by iOS home indicator
- update error copy to active voice: "The map failed to load."

## Testing
- `git diff --check`
- attempted `npm run test`
  - blocked by local npm install issues in this environment (empty `node_modules/esbuild` and prior `npm` internal error)

Closes #82