### PR TITLE
fix(scraper): ignore <table class="Note"> admonitions when parsing regions

### DIFF
--- a/scripts/scrape-veeam-regions.js
+++ b/scripts/scrape-veeam-regions.js
@@ -77,12 +77,24 @@ async function fetchWithRetry(url, maxRetries = 3) {
  */
 function parseRegionTable(html, serviceKey) {
   const regions = [];
-  
-  // Extract table rows
+
+  // Veeam help-center pages wrap region data in <table class="Blue_Table">.
+  // Other tables on the page (notably class="Note" admonitions on the M365 page)
+  // must be ignored, or their <tr>s leak in as bogus regions — see #95, #96.
+  const dataTablePattern = /<table[^>]*class="[^"]*\bBlue_Table\b[^"]*"[^>]*>([\s\S]*?)<\/table>/gi;
+  const dataTables = [...html.matchAll(dataTablePattern)].map(m => m[1]);
+
+  if (dataTables.length === 0) {
+    console.warn(`   ⚠️  No <table class="Blue_Table"> found for ${serviceKey}; page structure may have changed`);
+    return regions;
+  }
+
+  const scopedHtml = dataTables.join('\n');
+
   const tableRowPattern = /<tr[^>]*>(.*?)<\/tr>/gis;
   const cellPattern = /<t[dh][^>]*>(.*?)<\/t[dh]>/gis;
-  
-  const rows = [...html.matchAll(tableRowPattern)];
+
+  const rows = [...scopedHtml.matchAll(tableRowPattern)];
   
   for (let i = 0; i < rows.length; i++) {
     const rowHtml = rows[i][1];

--- a/scripts/test-scraper.js
+++ b/scripts/test-scraper.js
@@ -102,6 +102,47 @@ async function runTests() {
     assert(regions.some(r => r.regionName === 'Central US'), 'Should have Central US');
   });
 
+  // Regression: M365 page wraps a "note" admonition in <table class="Note">
+  // immediately before the data table. Those rows must not leak through as regions.
+  // See issues #95, #96.
+  await test('parseRegionTable ignores <table class="Note"> admonitions', async () => {
+    const sampleHtml = `
+      <p>Intro paragraph.</p>
+      <div><table border="0" cellspacing="0" cellpadding="0" class="Note">
+        <tr style="vertical-align:top">
+          <td><p class="T_NoteType"><span class="T_NoteType">note</span></p></td>
+        </tr>
+        <tr style="vertical-align:top">
+          <td><p class="Notes"><span class="Notes">Express backup data is stored in the Microsoft-specific region based on your configuration.</span></p></td>
+        </tr>
+      </table></div>
+      <div><table border="0" cellspacing="0" cellpadding="0" class="Blue_Table">
+        <caption>Backup Storage Regions</caption>
+        <tr><th><p>Global Region</p></th><th><p>Azure Region</p></th></tr>
+        <tr><td rowspan="2"><p>AMER</p></td><td><p>East US</p></td></tr>
+        <tr><td><p>West US</p></td></tr>
+      </table></div>
+    `;
+
+    const regions = parseRegionTable(sampleHtml, 'vdc_m365');
+
+    assertEqual(regions.length, 2, `Should parse exactly 2 regions, got ${regions.length}`);
+    assert(regions.some(r => r.regionName === 'East US'), 'Should have East US');
+    assert(regions.some(r => r.regionName === 'West US'), 'Should have West US');
+    assert(!regions.some(r => r.regionName === 'note'), 'Must not parse "note" as a region');
+    assert(!regions.some(r => /Express backup/.test(r.regionName)), 'Must not parse note body as a region');
+  });
+
+  // Defensive: if the page structure changes and no Blue_Table is found, return [].
+  await test('parseRegionTable returns empty when no Blue_Table is present', async () => {
+    const sampleHtml = `
+      <table class="Note"><tr><td>note</td></tr></table>
+      <table class="SomeOtherClass"><tr><td>East US</td></tr></table>
+    `;
+    const regions = parseRegionTable(sampleHtml, 'vdc_m365');
+    assertEqual(regions.length, 0, 'Should return no regions when no Blue_Table is present');
+  });
+
   // Test 3: findMatchingRegion function
   await test('findMatchingRegion finds regions by ID', async () => {
     const scrapedRegion = {


### PR DESCRIPTION
## Summary

- Scope `parseRegionTable` row extraction to `<table class="Blue_Table">` so the M365 page's preceding `<table class="Note">` admonition no longer leaks `note` and the Express-backup paragraph through as bogus regions.
- Return `[]` with a warning if no `Blue_Table` is present (defensive — page structure change), instead of silently falling back to whole-document scanning.
- Add regression tests covering both the Note-before-Blue_Table case and the no-Blue_Table fallback.

Closes #98. Once merged and the next scraper run produces a clean report, #95 and #96 can be closed.

## Test plan

- [x] `node scripts/test-scraper.js` — all 19 tests pass (17 existing + 2 new)
- [x] Re-parsed the live M365 HTML locally; output is 25 clean regions with no `note` row and no paragraph leak
- [ ] CI `pr-validation.yml` passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)