### PR TITLE
chore: merge release/1.3.0 back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Search result selection now opens popups for all regions, including those inside clusters (#23)
+## [1.3.0] - 2026-05-20
 
 ### Added
+- Sync filter state to URL query params for shareable filtered views (#91)
 - Playwright UI test suite with 33 tests covering search, filters, theme, popups, accessibility, and responsive design
 - Playwright UI tests job in PR validation CI workflow, reusing the Hugo build artifact from the existing build job
+
+### Fixed
+- Scraper: ignore `<table class="Note">` admonitions when parsing region tables (#99)
+- UI: dark mode select colours, safe area bottom padding, and error copy (#88)
+- UI: add `aria-hidden` to decorative SVGs for screen reader correctness (#87)
+- UI: align map UI with interface guidelines (#40)
+- Map: open popup for regions selected from search results, including clustered markers (#77)
+
+### Changed
+- Bump hono from 4.12.7 to 4.12.18 (#92, #93, #94)
+- Bump yaml from 2.8.2 to 2.8.3 (#89)
+
+### Documentation
+- Refresh `CLAUDE.md` with accurate paths and pointers (#97)
 
 ## [1.2.0] - 2026-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2026-03-21
+
+### Added
+- Azure Poland Central (Warsaw) region with VDC for Microsoft 365 and Entra ID support (#74)
+
+### Changed
+- Bump hono from 4.11.7 to 4.12.7 (#72)
+- Bump undici and wrangler to latest versions (#73)
+
+## [1.1.2] - 2025-01-22
+
+### Fixed
+- Add missing VDC for Azure service to NZ North and Austria East regions (#64)
+- Add 8 missing Azure regions for VDC for Azure support (#63)
+- Add missing VDC services to Azure regions (#52)
+
+## [1.1.1] - 2025-01-03
+
+### Added
+- Comprehensive gitflow release guide (`GITFLOW_RELEASE_GUIDE.md`)
+- AWS Taipei region corrected to `ap-east-2` (#45)
+- VDC M365 service added to Azure Korea Central (#43)
+
+### Changed
+- Bump hono from 4.11.4 to 4.11.7 (#41)
+- Bump wrangler from 4.54.0 to 4.59.1 (#39)
+
+## [1.1.0] - 2024-12-29
+
+### Added
+- REST API for programmatic access to service availability data (Hono + Cloudflare Workers)
+- OpenAPI/Scalar interactive API documentation at `/api/docs`
+- `/api/v1/regions/nearest` endpoint to find closest regions by coordinates
+- `/api/v1/regions/compare` endpoint to compare service availability across regions
+- `/api/v1/services/{serviceId}` endpoint with detailed per-service region lists
+- Region data for additional AWS and Azure regions
+- Automated region scraping and validation pipeline
+- LLM-friendly documentation (`static/llms.txt`, `static/llms-full.txt`)
+
+### Changed
+- Migrated deployment to Cloudflare Pages (from GitHub Pages)
+- Region data moved to individual YAML files per region
+
+## [1.0.0] - 2024-12-01
+
+### Added
+- Initial interactive map using Hugo, Leaflet.js, and Tailwind CSS
+- YAML-driven region data for AWS and Azure regions
+- Service filtering by provider, service type, and pricing tier
+- Dark-mode map with CartoDB Dark Matter tiles
+- GitHub Actions CI/CD pipeline
+
+[1.2.0]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.1.2...v1.2.0
+[1.1.2]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/comnam90/veeam-data-cloud-services-map/releases/tag/v1.0.0

--- a/GITFLOW_RELEASE_GUIDE.md
+++ b/GITFLOW_RELEASE_GUIDE.md
@@ -44,12 +44,14 @@ npm run build
 
 The release branch should be merged to `main` via a Pull Request:
 
+> ⚠️ **Important:** When creating the PR, always verify that the **base branch is set to `main`**, not `develop`. GitHub may default to a different base depending on how the branch was created.
+
 ```bash
 # Push release branch
 git push origin release/1.1.1
 
-# Create PR: release/1.1.1 → main
-# Title: "Release v1.1.1"
+# Create PR: release/1.1.1 → main   ← base MUST be main
+# Title: "chore(release): v1.1.1"
 # Include:
 # - List of changes since last release
 # - Version bump details

--- a/GITFLOW_RELEASE_GUIDE.md
+++ b/GITFLOW_RELEASE_GUIDE.md
@@ -189,10 +189,10 @@ Without merging back to develop:
 
 ## Current Release Status
 
-For the v1.1.1 release:
+For the v1.2.0 release:
 
 ✅ **Step 1**: Release branch created from develop
-✅ **Step 2**: Version bumped to 1.1.1  
+✅ **Step 2**: Version bumped to 1.2.0
 ✅ **Step 3**: Ready to merge to main (via current PR)
 ⏳ **Step 4**: After main merge, needs to merge back to develop
 ⏳ **Step 5**: Cleanup release branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veeam-data-cloud-services-map",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veeam-data-cloud-services-map",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@hono/zod-openapi": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veeam-data-cloud-services-map",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Interactive map and API for Veeam Data Cloud service availability across AWS and Azure regions",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veeam-data-cloud-services-map",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Interactive map and API for Veeam Data Cloud service availability across AWS and Azure regions",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veeam-data-cloud-services-map",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Interactive map and API for Veeam Data Cloud service availability across AWS and Azure regions",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Merge release v1.3.0 back to develop

Completes the gitflow release cycle by incorporating release changes into develop.

### Changes brought into develop

**From the v1.3.0 release (PR #100)**
- Version bump: 1.2.0 → 1.3.0 in `package.json` / `package-lock.json`
- `[1.3.0] - 2026-05-20` section in `CHANGELOG.md` (with new `[Unreleased]` placeholder)
- The merge commit that resolved divergence on the release branch

**Orphan commits from prior releases**
This PR also brings 7 commits that were stranded on `main` from earlier release cycles (v1.1.2 and v1.2.0) and never back-merged to `develop`:
- `4af8b52` chore(release): Release v1.2.0
- `6e9d852` docs: add warning to verify PR base is main in gitflow release step 3
- `828ef97` Merge branch 'main' into copilot/release-develop-into-main
- `dc60919` chore(release): bump version to 1.2.0
- `bc32791` Initial plan
- `135a563` Merge pull request #66 from comnam90/release/1.1.2
- `5cbadef` chore(release): bump version to 1.1.2

These are equivalent (in content) to commits already on develop with different SHAs, but pulling them across via this merge eliminates the structural divergence between `main` and `develop` going forward.

### Why this is needed

In gitflow, release changes must flow back to develop to ensure:
- Future features start from the correct version (1.3.0)
- Develop stays synchronized with production
- No version conflicts in the next release

### After merge

- [ ] Delete `release/1.3.0` and `chore/merge-release-1.3.0-to-develop` branches
- [ ] Verify `git log main..develop` and `git log develop..main` are clean (no divergence)

### Testing

No new code — pure merge. CI on this PR will validate the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)