### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-25
+
+### Changed
+- Mission Control redesign: rebuilt map UI with brand-aligned header, status strip, unified `.ctl` control primitive, restyled legend, and a new typography + theme token system (#103)
+- Map markers now render as hybrid POI dots displaying provider brand logos in place of plain provider-coloured circles (#103)
+- Cluster badges restyled to match the POI-dot treatment with an inverted brand accent for light/dark contrast; provider-mix strips removed (#103)
+- Popup template restructured with service icons, AA-contrast colours, and vault editions stacked as vertical pills on a single row (#103)
+- Adopted official Veeam help-center service names across the UI (e.g. "Azure Protection") and matched the providers legend icons to the map markers (#103)
+- Initial map view now fits to populated regions via `fitBounds` and tiles wrap so wide viewports no longer show empty edges (#103)
+
+### Added
+- Themed CSS tooltip pattern with `aria-label` replacing native `title=` tooltips for tier and control hints (#103)
+
+### Fixed
+- Search-click zoom escalates so popups for edge regions fit on screen, and the east map bound is extended so the NZ popup fits on mobile (#103)
+- Popup header zero-pads the available services count to stop layout shift between single- and double-digit values (#103)
+- Marker SVG `defs` IDs scoped per marker to prevent gradient/clip collisions across markers (#103)
+- Mobile header layout: filters stack below search and the multi-select chevron no longer overlaps the reset button (#103)
+- Live region count is exposed to assistive tech in the redesigned header (#103)
+- Removed lingering "status page" wording from the header and legend (#103)
+
+### Documentation
+- Added ADRs covering the Mission Control aesthetic and design tokens, official Veeam service naming, custom CSS tooltip pattern, cluster marker treatment, and initial map view + tile wrap (ADR-003 through ADR-007) (#103)
+- Added the Mission Control redesign implementation plan under `plans/mission-control-redesign/` (#103)
+
 ## [1.3.0] - 2026-05-20
 
 ### Added
@@ -80,6 +105,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dark-mode map with CartoDB Dark Matter tiles
 - GitHub Actions CI/CD pipeline
 
+[1.4.0]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.1.2...v1.2.0
 [1.1.2]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/comnam90/veeam-data-cloud-services-map/compare/v1.1.0...v1.1.1

--- a/docs/architecture/ADR-003-official-veeam-service-naming.md
+++ b/docs/architecture/ADR-003-official-veeam-service-naming.md
@@ -1,0 +1,66 @@
+# ADR-003: Adopt Official Veeam Help-Center Service Names
+
+**Status**: Accepted
+
+## Context
+
+The UI previously used a mix of ad-hoc service names produced from the YAML keys (`vdc_vault`, `vdc_m365`, `vdc_entra_id`, `vdc_salesforce`, `vdc_azure_backup`). The `serviceDisplayNames` map rendered them as a hybrid of ALL-CAPS brand acronyms and title-case product nouns — e.g. `M365 Protection`, `ENTRA ID Protection`, `SALESFORCE Protection`, `AZURE Protection`. The Vault row used short `Vault` / full `VAULT`.
+
+Two problems emerged from this:
+
+- The names didn’t match the section headings used in the official Veeam Data Cloud help-center user guide. Anyone reading both side-by-side had to mentally translate.
+- The service-filter checkbox label `Azure` collided with the Azure cloud provider label in the provider filter directly above it. Users could mistake the service filter for a provider filter.
+
+The names appear in three runtime contexts: the multi-select filter dropdown (short label), the filter-button label when one service is selected (short label), and the popup row per service (full label).
+
+## Decision Drivers
+
+- Vocabulary parity with the official Veeam documentation users are most likely to read alongside the map.
+- Unambiguous filter labels — no two top-level controls should share a label.
+- A single source of truth (`serviceDisplayNames`) drives every UI surface.
+
+## Decision
+
+Adopt the official help-center section names verbatim as the `full` display names:
+
+| YAML key | `short` (filter UI) | `full` (popup row) |
+| --- | --- | --- |
+| `vdc_vault` | `Vault` | `Veeam Data Cloud Vault` |
+| `vdc_m365` | `M365` | `Microsoft 365 Protection` |
+| `vdc_entra_id` | `Entra ID` | `Microsoft Entra ID Protection` |
+| `vdc_salesforce` | `Salesforce` | `Salesforce Protection` |
+| `vdc_azure_backup` | `Azure Protection` | `Microsoft Azure Protection` |
+
+The `short` for `vdc_azure_backup` is deliberately `Azure Protection` (not `Azure`) to disambiguate from the `Azure` cloud-provider filter that sits next to it in the header.
+
+All UI surfaces — multi-select checkbox labels, multi-select button label, and popup rows — read these strings through `getServiceDisplayName(key, type)`. The Playwright test that filters by the Azure service uses the `Azure Protection` label accordingly.
+
+## Options Considered
+
+### Option A: Keep the ad-hoc names
+
+- Pros: No code change; existing tests pass.
+- Cons: Vocabulary divergence from official docs; ongoing collision between the `Azure` service short and the `Azure` provider option.
+
+### Option B: Use only the short brand abbreviations everywhere (`Vault`, `M365`, `Entra`, `SF`, `Azure`)
+
+- Pros: Most compact UI; no wrapping.
+- Cons: `SF` is opaque without context; doesn't match any official Veeam naming; the `Azure` collision is unresolved.
+
+### Option C: Adopt the official help-center names (chosen)
+
+- Pros: Direct parity with documentation users already read; the `…Protection` suffix on the Azure service eliminates the provider collision naturally.
+- Cons: Long labels — `Microsoft Entra ID Protection` wraps in the popup row on narrow widths. Accepted because the wrapping is benign and the disambiguation gain is worth it.
+
+## Consequences
+
+- Any future service added to the YAML schema MUST register a `{ short, full }` entry in `serviceDisplayNames` using the canonical Veeam help-center heading as `full`. If the official docs ever rename a section, this map is the single place to update.
+- The `short` label for a new service MUST NOT collide with any existing provider value in `#providerFilter` (today: `Azure`, `AWS`). Where collision is unavoidable, follow the precedent set here and append `Protection` (or the equivalent product noun) to the `short`.
+- Documentation surfaces that mention services (info panel “What is this?” copy, `static/llms*.txt`, future help text) should use the canonical `full` names.
+- Tests asserting against service labels (e.g. `getByRole('checkbox', { name: 'Azure Protection' })`, `<input value=vdc_azure_backup> Azure Protection</label>` regex matches) must be updated in lockstep with any future rename.
+
+## Links
+
+- [PR #103](https://github.com/comnam90/veeam-data-cloud-services-map/pull/103) — the redesign that introduced this convention.
+- Mission Control Redesign implementation plan: `plans/mission-control-redesign/plan.md`
+- Veeam Data Cloud help-center: <https://www.veeam.com/products/veeam-data-cloud.html>

--- a/docs/architecture/ADR-004-mission-control-aesthetic-and-design-tokens.md
+++ b/docs/architecture/ADR-004-mission-control-aesthetic-and-design-tokens.md
@@ -1,0 +1,85 @@
+# ADR-004: Paired Mission Control / Workstation Aesthetic with CSS Design Tokens
+
+**Status**: Accepted
+
+## Context
+
+The SPA shipped initially with a generic Tailwind-driven SaaS dashboard look: system fonts, slate-grey palette with a green accent sprinkled evenly across the chrome, circle markers, and a popup that duplicated the Vault row when a region offered multiple editions. A UX review flagged the design as "competent but indistinguishable from every other cloud-service map" and identified specific issues: an Australia-centric default map view, hidden-on-mobile region count, no provider identity in markers, and amber styling collisions between AWS branding and warning callouts.
+
+A redesign was proposed, brainstormed across two directions ("Mission Control HUD" vs "Cartographic Atlas"), and the Mission Control direction was chosen. To make light mode a first-class peer of dark mode — not a flashlight-inversion of the cockpit aesthetic — a second variant (`Workstation`) was added: same DNA, calmer language. The two themes share the same component anatomy and only swap underlying tokens.
+
+The redesign is a single-file SPA change (`layouts/index.html`) because the project's architecture deliberately keeps the entire frontend in one Hugo template. Every visible component therefore has to pick its colours, fonts, and spacing values from somewhere — a Tailwind utility class, an inline style, or a custom CSS rule. Without a shared vocabulary the redesign would have continued the original pattern of scattering hex values across hundreds of lines and would have made future theme work hard.
+
+## Decision Drivers
+
+- One toggle, one product. Users flipping dark↔light should see the same product wearing different surfaces, not two different apps.
+- A small palette that has *meaning*. The accent green was previously decorative everywhere; in the new system it signals "live / available / current selection" specifically.
+- Mono-first typography (with a display serif/sans companion) to differentiate from the SaaS-dashboard pack and lean into the data-density of the map.
+- Provider identity at the marker level — users shouldn't need to read the legend to know whether a marker is AWS or Azure.
+- Theming must work without `.dark` / `.light` selectors on every component. The CSS variable system replaces dozens of paired overrides.
+
+## Decision
+
+### Tokenized theme system
+
+A single `:root` block defines the dark-mode (default) tokens. An `html.light` block re-declares the same token names with light-mode values. Every redesigned component reads colours through `var(--bg)`, `var(--text)`, `var(--accent)`, `var(--azure)`, `var(--aws)`, etc. No component declares hex values directly except where the value is provider-identity (e.g. AWS Squid Ink) and required to render in a context that doesn't inherit CSS variables (e.g. SVG attribute fills are wrapped in `var(--azure)` / `var(--aws)` for the same reason).
+
+Token domains:
+- Surface: `--bg`, `--bg-elev`, `--bg-elev-2`
+- Hairlines: `--border`, `--border-strong`
+- Ink: `--text`, `--text-mute`, `--text-dim`
+- Accent: `--accent`, `--accent-soft`, `--accent-glow`
+- Brand: `--azure`, `--aws`
+
+Dark accent is the fluorescent `#00ff88`; light accent is the muted `#00805a`. The two are intentionally non-identical — bright green on white reads as highlighter, muted green on black has no presence. Both still read as "Veeam green" emotionally.
+
+### Typography
+
+- `Space Grotesk` (weights 500, 700) for headlines and product nouns.
+- `JetBrains Mono` (weights 400, 500, 700) for body text, UI labels, status strip, popup metadata, and coordinate readouts.
+
+Loaded once via Google Fonts CDN with `display=swap` and a system-monospace fallback chain. The mono-first body type is the single biggest visual differentiator from the previous Tailwind-default look.
+
+### Component anatomy
+
+- Header: brand mark (pulsing dot) + live "status strip" telemetry (`Online · Regions X/Y · Providers 02 · Services 05`) + unified `.ctl` control primitive (search, selects, multi-select, icon buttons share one base class with `.ctl-*` modifiers).
+- Map: edge-to-edge with a tokenized `.panel-legend` and tokenized Leaflet zoom/attribution chrome. No rounded corners, no green glow.
+- Popup: one row per service (no edition-row duplication); each row carries a distinct monochrome service icon in `--accent` — the icon's presence signals "available", its shape signals which service; edition pills aligned right; vault edition pills hover-disclose commercial limits per [ADR-005](ADR-005-custom-css-tooltip-pattern.md); official Veeam service names per [ADR-003](ADR-003-official-veeam-service-naming.md).
+- Markers: `L.divIcon` glyphs in provider brand colour (Azure triangle / AWS cube) replacing the prior `L.circleMarker` SVG paths. Keyboard-navigable; the parent marker carries an accessible `alt`.
+- Info panel: same tokens, semantic class names (`.info-section`, `.info-link`, `.info-stat`) — no `bg-slate-*` / `bg-amber-500/10` mix.
+
+## Options Considered
+
+### Option A: Polish the existing design
+
+- Pros: Lowest risk; existing tests stay green; small diffs.
+- Cons: Doesn't address the "indistinguishable from every SaaS dashboard" feedback; the AWS amber/warning collision remains; mobile header still consumes ~15% of vertical space.
+
+### Option B: Cartographic Atlas direction
+
+- Pros: Genuinely distinctive (serif headlines, parchment palette, atlas vibe); zero competitors in this product space.
+- Cons: Stronger departure from Veeam brand voice; the light-mode-first treatment doesn't translate as cleanly to a dark dashboard mode; risk of feeling like a marketing site rather than an operational tool.
+
+### Option C: Mission Control HUD + Workstation light (chosen)
+
+- Pros: Reads as a polished operational tool; live status strip + mono numerals lean into the data-density users care about; the dark/light pair shares one design system rather than being two separate aesthetics; CSS tokens scale to future theme work (e.g. a hypothetical high-contrast mode) without requiring `.theme-x` selectors on every component.
+- Cons: Bigger up-front diff; Google Fonts adds a render-blocking stylesheet (mitigated by `display=swap` and a system fallback chain); some popup rows can wrap due to the longer official service names.
+
+## Consequences
+
+- New UI components MUST read colours/spacing through the existing tokens. Adding a new hardcoded hex value is a smell — either a new token is needed (justify in the PR), or the component should pick the closest existing token.
+- Theme variants are added by extending `:root` / `html.light` (and potentially a future `html.high-contrast`, `html.print`, etc.). Components should NOT branch on `html.light` directly except where light mode genuinely needs a different *structure* (e.g. drop-shadow vs glow), and even then prefer adjusting tokens.
+- Typography is a brand-level choice. If a future redesign wants different fonts, this ADR is the document to supersede; doing it piecemeal will fragment the system.
+- The accent green is reserved for "live / active / available / focus". Don't use it as decoration. The provider blue/orange tokens are reserved for provider identity. Don't repurpose them.
+- Each service registered in `serviceDisplayNames` MUST also register a corresponding inline SVG in `serviceIcons` (in `layouts/index.html`). Icons are simple monochrome geometric shapes that render crisply at 14px, using `stroke="currentColor"` so they inherit `--accent`. The shape carries service identity; the colour carries the "available" semantic. A service without an icon falls back to a generic checkmark — acceptable as a defensive default, not as a long-lived state.
+- Metadata text tokens (`--text-dim`, `--text-mute`) carry a hard floor: both MUST clear WCAG AA against the popup background (`--bg-elev`) at the 9–10px sizes used in the popup header and coordinate readouts. This UI is regularly shown on projectors and screen-shared over compressed video; a token value that looks crisp on the design machine but fades on lossy displays violates the brief. Tune the values, not the font sizes, if a future contrast regression appears.
+- Marker primitive: `L.divIcon` is the contract. Reverting to `L.circleMarker` would re-introduce the accessibility regression (no `keyboard: true`, no `alt`) and break the test selectors that target `.leaflet-marker-icon .map-marker-dot`.
+- Cluster icons (`.cluster-small`, `.cluster-medium`, `.cluster-large`) were deliberately left on the old colour system in this redesign — a known follow-up, resolved by [ADR-006](ADR-006-cluster-marker-visual-treatment.md). The resolution re-tokenises clusters to `var(--accent)` only; per-provider colouring at cluster level (`--azure` / `--aws`) was considered and rejected because aggregated provider colouring destroyed the cluster/marker visual hierarchy — see ADR-006 §Options Considered.
+- Hugo's HTML minifier strips quotes around single-token attribute values. Smoke tests using `curl | grep` should account for this (`class=hud`, not `class="hud"`).
+
+## Links
+
+- [PR #103](https://github.com/comnam90/veeam-data-cloud-services-map/pull/103) — the redesign that introduced this aesthetic.
+- Implementation plan: `plans/mission-control-redesign/plan.md`
+- [ADR-003](ADR-003-official-veeam-service-naming.md) — service-naming convention used inside the popup component defined by this ADR.
+- UX review and mockups (session output): the brainstorming explored Mission Control and Cartographic Atlas directions at desktop + mobile, both themes, before this aesthetic was chosen.

--- a/docs/architecture/ADR-005-custom-css-tooltip-pattern.md
+++ b/docs/architecture/ADR-005-custom-css-tooltip-pattern.md
@@ -1,0 +1,81 @@
+# ADR-005: Custom CSS Tooltip Pattern for In-App Hover Affordances
+
+**Status**: Accepted
+
+## Context
+
+The Mission Control popup ([ADR-004](ADR-004-mission-control-aesthetic-and-design-tokens.md)) introduced vault tier pills (`Foundation · Core`, `Advanced · Core`, etc.) that buyers visually scan to confirm regional support. A code-review pass on PR #103 surfaced that the pills give no inline disclosure of the commercial limits each edition carries (e.g. Foundation's 20% fair-usage restore cap, Advanced's unlimited restores). Buyers had to leave the page for that context.
+
+The obvious default — the native HTML `title=` attribute — was explicitly rejected for two reasons: a ~700–1000ms hover delay before the bubble appears, and OS-native styling that clashes with the curated dark/light dashboard aesthetic ADR-004 establishes. The audience and viewing context make both flaws acute: this UI is buyer-facing and is regularly screen-shared over compressed video calls or shown on projectors, where delayed reveals are confusing and OS chrome is jarring.
+
+The vault tier disclosure is the first in-app tooltip in this UI. Without a documented pattern, future hover affordances (filter chips, provider chips, region-status indicators, future capability badges) will fragment between contributors' instincts. The decision and its trade-offs need to be pinned down once.
+
+## Decision Drivers
+
+- Visual consistency with the Mission Control aesthetic — tooltips MUST read as part of the same product, not an OS overlay.
+- Zero perceptible latency on hover. The information should appear instantly.
+- Accessibility parity with native `title=`. Native ships free keyboard + screen-reader support; a custom replacement MUST replicate both, not silently regress.
+- No new runtime dependency. The project ships a single-file SPA; adding a tooltip library (Tippy.js, Floating UI, etc.) for one use case is over-investment.
+- The pattern must work inside a Leaflet popup, which adds overflow/z-index constraints absent from a generic page.
+
+## Decision
+
+Use a CSS-only tooltip driven by a `data-tooltip` attribute and a `::after` pseudo-element. Every interactive element that needs an in-app tooltip MUST carry all four pieces:
+
+1. **`data-tooltip="<copy>"`** — the visible bubble reads this via `content: attr(data-tooltip)`.
+2. **`aria-label="<element text>. <copy>"`** — replicates the screen-reader announcement that `title=` would have provided.
+3. **`tabindex="0"`** — exposes the element to keyboard focus so the same bubble triggers on `:focus-visible`.
+4. **CSS triggers on both `:hover` and `:focus-visible`** — mouse AND keyboard users see the disclosure.
+
+The bubble styles MUST use existing design tokens from [ADR-004](ADR-004-mission-control-aesthetic-and-design-tokens.md) (`--bg-elev-2` background, `--border-strong` border, `--text` ink, `--bg-elev-2` shadow tint) so the tooltip themes with the rest of the dashboard.
+
+Reduced-motion users get an instant show/hide:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+    .popup-svc .pill[data-tooltip]::after { transition: none; }
+}
+```
+
+### Leaflet overflow + stacking
+
+The `.leaflet-popup-content-wrapper` ships with `overflow: hidden` to clip rounded corners against the inner provider-strip background. A tooltip rendered as a child pseudo-element will be clipped by that wrapper. The fix is a scoped override:
+
+```css
+.leaflet-popup-content-wrapper:has(.popup-card) { overflow: visible; }
+```
+
+`:has()` keeps the override targeted to our redesigned popup so any other Leaflet popup the project might later add keeps its default clipping. The bubble's `z-index` is set to `1000` to sit cleanly above Leaflet's popup pane (default ≤700).
+
+## Options Considered
+
+### Option A: Native HTML `title=` attribute
+
+- Pros: Zero new CSS/JS; ships full a11y (screen-reader + keyboard) by default.
+- Cons: ~700–1000ms hover delay; OS-default styling cannot be themed; clashes with the Mission Control aesthetic; the latency is confusing in the screen-share contexts this UI is used in.
+
+### Option B: JS-driven tooltip library (Tippy.js, Floating UI, etc.)
+
+- Pros: Polished out-of-the-box; handles edge positioning, collision avoidance, and multi-line copy.
+- Cons: New runtime dependency in a single-file SPA; adds bundle size and build steps for one initial use case; the tooltip needs are simple enough that CSS-only solves them without a library.
+
+### Option C: CSS-only `data-tooltip` + `::after` (chosen)
+
+- Pros: Zero dependency; instant on hover; themed via existing CSS tokens; pseudo-element keeps the markup clean; pattern generalises naturally to other hover affordances.
+- Cons: Single-line copy is best (multi-line works but needs `white-space: normal` + explicit `max-width`); collision avoidance is manual (positioning above the element is fine for in-popup pills but may need re-evaluation if the trigger is near the top of the viewport); the overflow + z-index gotchas require attention any time the pattern is adopted inside a clipped parent.
+
+## Consequences
+
+- New hover affordances in `layouts/index.html` MUST use this pattern. Don't reach for `title=` even for "simple" in-app cases — the latency and styling drift compound across components.
+  - Exception: `title=` on `<a>` tags pointing to external resources is fine. Those aren't competing with the dashboard aesthetic.
+- All four pieces (`data-tooltip`, `aria-label`, `tabindex=0`, hover + focus-visible CSS) are required together. Skipping any one breaks either a11y or keyboard parity.
+- When extending the pattern to a new context, audit the parent chain for `overflow: hidden` or `overflow: clip`. Add a scoped `:has()` override (preferred) or restructure the parent.
+- Tooltip CSS currently lives scoped under `.popup-svc .pill[data-tooltip]`. The second use of the pattern in another component should trigger a refactor: promote the rules to a generic `[data-tooltip]` selector and keep only component-specific positioning overrides locally. This ADR is the place to record that promotion when it happens.
+- Tooltip strings that carry product, commercial, or compliance claims (e.g. fair-usage restore limits) MUST be treated as commercial copy — coordinate edits with product. A code comment marking such strings as commercial disclosures is appropriate where the WHY isn't obvious from the variable name.
+- Tests asserting tooltip behaviour SHOULD assert on the attributes (`data-tooltip`, `aria-label`, `tabindex`) rather than the rendered `::after` content, since `::after` is not in the DOM and is awkward to query reliably in Playwright. The `aria-label` is the most stable signal for screen-reader equivalence.
+
+## Links
+
+- [PR #103](https://github.com/comnam90/veeam-data-cloud-services-map/pull/103) — the redesign and the popup that introduced this pattern.
+- [ADR-004](ADR-004-mission-control-aesthetic-and-design-tokens.md) — design tokens consumed by the tooltip bubble styling.
+- Initial use: `vaultEditionDescriptions` in `layouts/index.html`, rendered by the vault tier pill generator.

--- a/docs/architecture/ADR-006-cluster-marker-visual-treatment.md
+++ b/docs/architecture/ADR-006-cluster-marker-visual-treatment.md
@@ -1,0 +1,85 @@
+# ADR-006: Cluster Marker Visual Treatment
+
+**Status**: Accepted
+
+## Context
+
+PR #103 ([ADR-004](ADR-004-mission-control-aesthetic-and-design-tokens.md)) redesigned the individual region markers from `L.circleMarker` SVG paths to `L.divIcon` glyphs, and a follow-up upgraded them again to "Hybrid POI dots" — 28px white circles with a subtle border, soft drop shadow, and a brand SVG inside. The cluster bubbles, however, were still on the pre-redesign look: green/teal gradient backgrounds with a frosted ring, plus a 4px-tall blue/orange `.cluster-providers` strip beneath each cluster that visualised the AWS/Azure ratio inside. ADR-004 §Consequences explicitly flagged this as a known follow-up.
+
+That left two problems: clusters and POI dots read as two different design languages on the same map; and the provider mix bars added decorative noise at world/continent zoom where buyers don't make per-provider decisions yet — they zoom in for that.
+
+A first iteration aligned clusters with the POI dot surface entirely — same white background, subtle border, soft shadow. It shipped (commit `5450ddf`) and was rejected on first eyeball on two grounds: (a) on the Workstation (light) theme the white cluster washed out against the lightened tile palette; (b) cluster and individual marker became visually indistinguishable, destroying the at-a-glance signal that "this is a group, not one region." That iteration produced the principle this ADR records: matching the POI surface is wrong; the cluster must differentiate, in both themes, by design.
+
+This ADR pins the visual-hierarchy principle and the resulting treatment so future contributors don't collapse the two primitives back together.
+
+## Decision Drivers
+
+- A cluster must read as "many" and a POI dot must read as "one" at a glance. They share map space; they cannot share surface.
+- Both themes are first-class (per ADR-004). A cluster colour that works on dark tiles but vanishes on light tiles is a bug, not a styling preference.
+- The token system (ADR-004) already binds `--accent` to "live / available / current selection". Clusters carry the same semantic — they are the aggregated population of available regions. Re-using `--accent` is consistent, not decorative.
+- Provider mix at world/continent zoom is decorative; the per-region provider identity is already encoded in the POI dot's brand SVG and reached by zooming in.
+- Cluster count is a real buyer signal — a 30-region cluster should physically read heavier than a 4-region one. Size tiers carry that signal in peripheral vision; the count number alone doesn't.
+
+## Decision
+
+### Inverted brand badge
+
+`.cluster-marker` paints `var(--accent)` background, white count text, and a 2px white ring. The token auto-themes (`#00ff88` dark, `#00805a` light per ADR-004); white text + white ring read against both. Drop shadow is `0 2px 6px rgba(0, 0, 0, 0.35)` at rest, deepening to `0 4px 12px rgba(0, 0, 0, 0.45)` on hover — both stronger than the POI dot's `0 2px 6px rgba(0, 0, 0, 0.25)` so the cluster sits visually above an individual marker on the same tile.
+
+Token contract follows ADR-004: the colour is read through the token, not declared as a hex. White (`#ffffff`) is the only literal — it is semantic (the "separator against the map" affordance, plus max-contrast count text), not branded.
+
+A defensive `html.light .cluster-marker` override declares the same accent + white text + white ring explicitly. The override is not strictly required since `var(--accent)` already auto-themes; it exists as a cascade-anchor so a future light-mode adjustment cannot accidentally desaturate the cluster.
+
+### Size tiers preserved
+
+Three tiers stay — `.cluster-small` (36×36, 12px), `.cluster-medium` (44×44, 14px), `.cluster-large` (52×52, 16px) — keyed off `CLUSTER_SIZE_THRESHOLDS` (MEDIUM=5, LARGE=20). Three discrete sizes snap to recognisable "small / medium / large" categories in peripheral vision; a continuous size interpolation would be harder to compare across the map at a glance.
+
+The Leaflet `iconSize` / `iconAnchor` stays at `L.point(52, 52)` / `L.point(26, 26)` uniformly across all tiers. The over-sized click target on small clusters is a deliberate touch-friendliness affordance and keeps the disbanding animation smooth at the breakpoint.
+
+### Provider mix bars removed
+
+The `.cluster-providers` / `.azure-bar` / `.aws-bar` CSS rules, the `PROVIDER_BAR` constant, and the per-cluster `markers.forEach(provider counting)` block are deleted together. The cluster icon is now a single accent badge with a count and a tier class — nothing else.
+
+This is recorded as a deliberate non-feature: the AWS/Azure mix is intentionally NOT surfaced at cluster level. The per-region provider identity is reached by zooming past `CLUSTER_CONFIG.DISABLE_AT_ZOOM` (currently 6), where the POI dots' brand SVGs carry the signal.
+
+## Options Considered
+
+### Option A: Keep clusters on the pre-redesign green-gradient look
+
+- Pros: Zero change; familiar to anyone who'd already seen the prior UI.
+- Cons: Two design languages on the same map; provider strips still add noise at world zoom; leaves ADR-004:77's flagged follow-up unresolved.
+
+### Option B: Match clusters to the POI-dot surface (white + subtle border + soft shadow)
+
+- Pros: Single visual language; cleanest at first glance on dark tiles.
+- Cons: Washes out on the Workstation light theme; collapses the cluster/marker visual hierarchy — a user can no longer tell at a glance whether they're looking at one region or many. Shipped briefly as commit `5450ddf` and rejected on empirical review.
+
+### Option C: Per-provider cluster colouring using `--azure` + `--aws`
+
+- Pros: Carries provider identity all the way to cluster level; would have aligned with ADR-004:77's original wording ("should reuse `--accent`, `--azure`, `--aws`").
+- Cons: A two-tone cluster (split / striped / sectored) re-introduces exactly the noise the provider-mix bars added; a single-provider-cluster pure-azure or pure-aws colouring would mislead when the cluster is mixed; clusters are aggregations and the cleanest semantic is "available regions, count of N", not "this many of brand X."
+
+### Option D: Inverted brand badge — `var(--accent)` background, white text + white ring (chosen)
+
+- Pros: Re-uses ADR-004's accent semantic ("live / available / aggregated"); the auto-themed token works on both surfaces without per-theme hex variants; colour-inverted vs the white POI dot differentiates the two primitives while staying inside the same palette; removing provider bars simplifies the cluster pipeline (three CSS rules, one constant, one loop deleted).
+- Cons: Heavier eye-weight at world zoom with many small clusters — mitigated by the smaller `.cluster-small` size (36px) and the still-soft shadow. If this becomes a problem the response is to tune token values, not to reintroduce per-tier hex variants.
+
+## Consequences
+
+- Cluster surfaces MUST be painted from `var(--accent)`. A new contributor reaching for a fresh hex value or for `--azure` / `--aws` at cluster level is a smell — clusters own the accent semantic; per-provider colouring at the aggregated level was considered and rejected (Option C).
+- Provider mix at cluster level is a deliberate non-feature. Don't re-add `.cluster-providers` strips, sector arcs, halftone fills, or other "AWS:Azure ratio" treatments to the cluster icon. The provider signal lives on individual POI dots (ADR-004 marker primitive) and is reached by zooming in past `CLUSTER_CONFIG.DISABLE_AT_ZOOM`.
+- Size tiers MUST stay discrete, not interpolated. Three sizes keyed off `CLUSTER_SIZE_THRESHOLDS` is the contract.
+- The `html.light .cluster-marker` override is a cascade-anchor and should not be removed even though it appears redundant against the auto-themed `var(--accent)`. Removing it makes a future light-mode experiment one bad rule away from desaturating the cluster.
+- White (`#ffffff`) on the ring and the count text is the only literal allowed inside `.cluster-marker`. It is semantic (separation from the map; max-contrast count), not a brand colour. Other components needing a "ring against the map" affordance should reach for the same literal rather than introducing a `--ring` token unless multiple components share the need.
+- Cluster click-target stays at `L.point(52, 52)` / `L.point(26, 26)` uniformly across tiers. The generous touch target on small clusters is a deliberate touch-friendliness affordance, not an oversight.
+- `MarkerCluster.Default.css` (loaded at `index.html:21`) ships green pastel backgrounds for `.marker-cluster` and its inner `div`. The three `background: transparent !important` neutralisers above the cluster styles MUST stay; removing them re-introduces the plugin default behind the accent badge.
+- Existing Playwright selectors target `.leaflet-marker-icon .map-marker-dot` only; cluster styling changes don't touch them and shouldn't. Cluster-specific visual assertions are intentionally absent — they'd be more fragile than valuable for a CSS-only contract. If a cluster regression needs a regression test in the future, prefer asserting the DOM contract (`.cluster-marker` exists; `.cluster-small|medium|large` is applied per `CLUSTER_SIZE_THRESHOLDS`) over the rendered pixels.
+
+## Links
+
+- [ADR-004](ADR-004-mission-control-aesthetic-and-design-tokens.md) §Consequences — cluster-icons follow-up flagged at the line referenced from ADR-004 itself; this ADR is the resolution.
+- [ADR-005](ADR-005-custom-css-tooltip-pattern.md) — companion ADR for another component-level extension of ADR-004's token system.
+- Commits on `feature/mission-control-redesign`:
+  - `5450ddf` — Option B (white badges) shipped and rejected; the iteration this ADR explicitly supersedes on visual-hierarchy grounds.
+  - `7ed291c` — provider-mix strips removed from HTML, JS, and CSS together.
+  - `4fd6dcc` — inverted brand badge (the treatment this ADR records).

--- a/docs/architecture/ADR-007-initial-map-view-and-tile-wrap.md
+++ b/docs/architecture/ADR-007-initial-map-view-and-tile-wrap.md
@@ -1,0 +1,104 @@
+# ADR-007: Responsive Initial Map View via `fitBounds` with Tile Wrap
+
+**Status**: Accepted
+
+## Context
+
+The Leaflet map historically opened Australia-centric with a hard-coded `center: [-25, 140]`, `zoom: 3`, `minZoom: 3.0` — a holdover from the project's origin in Auckland that kept hiding because it framed the dev team's home region. During the mission control redesign ([ADR-004](ADR-004-mission-control-aesthetic-and-design-tokens.md)) commit `5bafc11` re-centred the initial view to `center: [25, 10]`, `zoom: 2`, `minZoom: 2.0` for a globally-balanced first impression. On a 2K (≈2560 px wide) desktop that re-centred view surfaced two problems together: the world wrapped horizontally 2–3 times (the world at zoom 2 is only 1024 px wide, leaving the wider viewport to be re-filled by adjacent copies), and a large blank vertical band sat above the populated latitudes (markers cluster between roughly −40° and +55° lat but the static view was centred at lat 25 with no padding negotiation). Both static framings — Australia-centric and globally-centred — encoded a single assumed viewport; the wide-display review made clear that *any* hard-coded `center`/`zoom` pair would lose on some screen size.
+
+The audience is buyer / pre-sales (per [ADR-004](ADR-004-mission-control-aesthetic-and-design-tokens.md) drivers): the map is presented on whatever screen the demo happens to land on — laptops, 2K external monitors, 4K conference TVs, and incidentally the mobile portraits the Playwright suite (Pixel 7, iPhone 15 Pro) covers as part of the responsive contract. A single solution had to work across all of them without an arbitrary breakpoint forest.
+
+A first iteration (commits `63415cd`, `0234bde`) replaced the static view with `fitBounds` and added `noWrap: true` to the tile layers to stop the multi-world repeat. It shipped and was rejected on second eyeball: the populated band now framed correctly, but the world clipped to grey edges on wide displays (at zoom 3 the world is 2048 px and a 2K viewport leaves ~256 px of grey on each side). The user feedback — "I'm ok with a little edge wrap to fill this" — produced the principle this ADR records: tile wrap is a free pixel filler at the right zoom and `fitBounds` is the mechanism that keeps the wrap small.
+
+## Decision Drivers
+
+- Initial view must adapt across laptop, 2K, 4K, and mobile portrait without per-breakpoint hard-coded zoom values; new screen sizes appear and the design must not need a new conditional each time.
+- The thing we want to fit on screen is the *region data*, not the world. Deriving the view from `regions[].coords` is the only honest way to keep this true as regions get added.
+- The cluster signal ([ADR-006](ADR-006-cluster-marker-visual-treatment.md)) — at-a-glance "many vs one" via cluster vs POI dot — is part of the map's primary affordance. The initial zoom must not collapse it. On mobile portrait specifically, isolated Azure regions (Australia, NZ, South Africa, Korea) must still read as individual markers; this is empirically asserted by `tests/ui.spec.ts:113` and `:128`.
+- The off-canvas space on wide viewports has two valid renderings: grey (tile clip) or adjacent world copy (tile wrap). At a `fitBounds`-chosen zoom the wrap is small enough to feel like "edge fill", not "the map is broken." Grey edges read as broken.
+- Initial zoom and interactive zoom are different contracts. The user can drive the map to any zoom in the `[minZoom, maxZoom]` range; the *initial* zoom should never overshoot continent scale on first load.
+
+## Decision
+
+### `fitBounds` on `regions[].coords`
+
+Replaces the static `center`/`zoom` pair. Built once after tile-layer attachment:
+
+```js
+const regionLatLngs = regions
+    .filter(r => Array.isArray(r.coords) && r.coords.length === 2)
+    .map(r => r.coords);
+map.fitBounds(L.latLngBounds(regionLatLngs), {
+    padding: [48, 48],
+    maxZoom: 3,
+    animate: false
+});
+```
+
+- `padding: [48, 48]` keeps edge markers off the header and bottom legend chrome without a CSS gap.
+- `maxZoom: 3` caps the *initial* zoom so 4K and 5K displays don't overshoot to a continent-fragment view on first load. This ceiling is deliberately lower than the map's `maxZoom: 6` — interactive zoom past 3 is a user choice, not an automatic one.
+- `animate: false` — the very first view is not a motion; no users have interacted yet.
+- No resize listener. Once `fitBounds` has run on load, the view stays where the user puts it via interaction.
+
+### `minZoom: 2`, not 1
+
+`fitBounds` clamps to `map.minZoom`. On Pixel 7 (412×915) and iPhone 15 Pro (393×852) portraits the natural fit is zoom 1, and at zoom 1 every Azure marker collapses into clusters — including the geographically isolated ones (Australia, NZ, South Africa) that read as "single region per continent" cues on the wider screens. Lowering `minZoom` to 1 also broke `tests/ui.spec.ts:113` (`should filter regions by Azure provider`) on both Mobile Chrome and Mobile Safari, because the assertion `.leaflet-marker-icon .map-marker-dot` count > 0 requires un-clustered individual markers. The test is downstream of the UX regression, not the cause of it.
+
+Keeping `minZoom: 2` means mobile portrait clamps to the previous default (so the touch UX on phones did not change). Only wide desktops benefit from the new `fitBounds`-chosen zoom of 3.
+
+### Tile wrap is on (no `noWrap`), `worldCopyJump: true`
+
+Both tile layers omit the `noWrap` option, so default Leaflet wrap behaviour applies. `worldCopyJump: true` is restored at map level as the partner of wrapped tiles — without it, marker positions can drift relative to the visible world copy when the user pans across the antimeridian.
+
+At zoom 3 the rendered world is 2048 px wide. On a 2K viewport this leaves ~256 px of edge on each side, which is filled by the adjacent world copy — "a little edge wrap." On a 4K viewport the wrap is closer to half a world per side; still acceptable because the populated continents stay anchored to the canonical copy and the duplicated regions are unpopulated ocean.
+
+`maxBounds: [[-60, -185], [90, 185]]` is unchanged from the prior code. It governs *interactive* pan limits, not the initial framing, and the ±185° lng range deliberately permits a small pan into the wrap zone.
+
+## Options Considered
+
+### Option A: Hard-coded per-breakpoint zoom
+
+`if (window.innerWidth >= 2200) zoom = 3 else zoom = 2`, optionally with more steps.
+
+- Pros: Simplest possible code; deterministic.
+- Cons: Arbitrary thresholds (every breakpoint is someone's guess); doesn't adapt to ultrawide / 4K / 5K without more conditionals; doesn't adapt as the region distribution changes over time; the breakpoint is not derived from the thing it claims to optimise for.
+
+### Option B: `fitBounds` + `noWrap: true`
+
+The first iteration. Shipped briefly in `63415cd` and `0234bde`.
+
+- Pros: Single world copy, deterministic rendering, no risk of wrap-related marker drift.
+- Cons: Clips the world to grey edges on wide displays — at zoom 3 on 2K the rendered world is 2048 px in a 2560 px viewport, so ~256 px of grey on each side; rejected on visual review. Same pattern as ADR-006 Option B: an option that looks cleaner on paper and worse on the screen.
+
+### Option C: `fitBounds` + lower `minZoom: 1`
+
+Let mobile portrait pick the natural fit instead of clamping.
+
+- Pros: All regions visible on initial mobile load without panning.
+- Cons: Empirical UX regression — at zoom 1 the cluster signal collapses for isolated regions, and `tests/ui.spec.ts:113`/`:128` fail on both mobile projects (the test is the early warning of a real visual problem, not the problem itself).
+
+### Option D: `fitBounds` + tile wrap (chosen)
+
+`noWrap` omitted, `worldCopyJump: true` restored, `maxZoom: 3` ceiling on the fit, `minZoom: 2` clamp.
+
+- Pros: Responsive across viewport sizes from mobile portrait to 4K with no breakpoint conditional; preserves the cluster signal on mobile; fills wide-display edges with the cheapest available rendering (wrap) instead of grey; all existing Playwright tests pass.
+- Cons: `worldCopyJump` and tile wrap are a coupled pair — turning off one requires turning off the other; on very wide displays (4K+) the wrap can occupy close to half the off-canvas width, which a future contributor may misread as the original "world repeats three times" bug. This ADR exists primarily to prevent that misreading.
+
+## Consequences
+
+- Initial view MUST be derived from `regions[].coords` via `fitBounds`. A new contributor adding `center: [...]` or `zoom: N` to the `L.map()` options block is a smell; that responsibility moved to Leaflet, computed from the data.
+- `noWrap: true` on the tile layer is a defect, not an improvement. The grey-edge clip on wide displays is the failure mode it produces. If wrap-related side effects appear (marker drift, unbounded pan), fix them in `worldCopyJump` and `maxBounds` rather than disabling wrap.
+- `worldCopyJump: true` MUST stay enabled while tile wrap is enabled. The pair is a contract: one without the other is a UX regression (either grey edges or marker drift). Removing `worldCopyJump` is acceptable only as part of a deliberate move back to `noWrap: true`, which this ADR rejects.
+- `minZoom: 2` is a load-bearing constraint, not an arbitrary floor. Lowering it to 1 collapses isolated regions into clusters on mobile portrait and breaks the cluster affordance ADR-006 records.
+- `maxZoom: 3` inside the `fitBounds` call is the *initial-view ceiling*, intentionally lower than the map's `maxZoom: 6`. Bumping it to match the map's max makes 4K displays open at continent-fragment scale on first load.
+- No resize listener for the initial view. A debounced resize re-fit would silently undo the user's zoom and pan when the browser is resized — hostile UX. If a viewport-aware re-fit becomes a need, gate it behind a user action (e.g., a "fit to data" control), not on resize.
+- The existing Playwright contract — `tests/ui.spec.ts:113`/`:128` (provider filter → un-clustered marker count > 0) and `:479` (un-cluster + click marker) — is part of the contract this ADR records. A change here that breaks either is most likely a regression in this decision, not the test.
+
+## Links
+
+- [ADR-004](ADR-004-mission-control-aesthetic-and-design-tokens.md) — mission control aesthetic; the redesign that surfaced the wide-display review and the audience driver this ADR inherits.
+- [ADR-006](ADR-006-cluster-marker-visual-treatment.md) — cluster marker treatment; this ADR depends on the cluster/POI visual hierarchy holding at mobile portrait zoom.
+- Commits on `feature/mission-control-redesign`:
+  - `63415cd` — first attempt: `fitBounds` + `noWrap: true`; clipped edges on wide displays.
+  - `0234bde` — `minZoom` restored to 2 after the mobile cluster-signal regression broke Mobile Chrome / Mobile Safari filter tests.
+  - `c6a3180` — tile wrap re-enabled, `worldCopyJump` restored (the treatment this ADR records).

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Interactive map of Veeam Data Cloud service availability across AWS and Azure regions.">
-    <meta name="theme-color" content="#0f172a" id="themeColorMeta">
+    <meta name="theme-color" content="#0a0d12" id="themeColorMeta">
     <meta name="color-scheme" content="light dark">
     <title>{{ .Site.Title }}</title>
     
@@ -12,7 +12,10 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="preconnect" href="https://unpkg.com">
     <link rel="preconnect" href="https://static.cloudflareinsights.com" crossorigin>
-    
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=JetBrains+Mono:wght@400;500;700&display=swap">
+
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
     <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css"/>
     <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css"/>
@@ -22,15 +25,48 @@
     <style type="text/tailwindcss">
         @custom-variant dark (&:where(.dark, .dark *));
         @custom-variant light (&:where(.light, .light *));
-        
-        body { 
-            background-color: #0f172a; 
-            color: white;
+
+        :root {
+            /* Dark tokens (default) */
+            --bg: #0a0d12;
+            --bg-elev: #11151c;
+            --bg-elev-2: #161b24;
+            --border: #232a35;
+            --border-strong: #2f3744;
+            --text: #e6edf3;
+            --text-mute: #a4adba;
+            --text-dim: #7a8290;
+            --accent: #00ff88;
+            --accent-soft: rgba(0, 255, 136, 0.10);
+            --accent-glow: rgba(0, 255, 136, 0.35);
+            --azure: #4ea3ff;
+            --aws: #ff9d3d;
+        }
+        html.light {
+            --bg: #fafbfc;
+            --bg-elev: #ffffff;
+            --bg-elev-2: #f4f6f8;
+            --border: #e5e8ec;
+            --border-strong: #d0d5da;
+            --text: #1a202c;
+            --text-mute: #4a5364;
+            --text-dim: #6b7384;
+            --accent: #00805a;
+            --accent-soft: rgba(0, 128, 90, 0.10);
+            --accent-glow: rgba(0, 128, 90, 0.20);
+            --azure: #2c5fa8;
+            --aws: #d97506;
+        }
+
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'JetBrains Mono', ui-monospace, monospace;
+            font-size: 13px;
+            letter-spacing: 0.005em;
             transition: background-color 0.3s ease, color 0.3s ease;
             touch-action: manipulation;
         }
-        .dark body { background-color: #0f172a; color: white; }
-        .light body { background-color: #f1f5f9; color: #0f172a; }
         
         /* Full height layout using flexbox */
         .app-container {
@@ -46,24 +82,36 @@
             padding-bottom: env(safe-area-inset-bottom);
         }
         
-        #map { 
-            height: 100%;
-            width: 100%; 
-            border-radius: 0.75rem; 
-            border: 1px solid #334155;
-            box-shadow: 0 0 40px rgba(0, 209, 95, 0.08), 0 4px 20px rgba(0, 0, 0, 0.3);
-            transition: box-shadow 0.3s ease, border-color 0.3s ease;
+        #map {
+            width: 100%; height: 100%;
+            background: var(--bg);
         }
-        @media (max-width: 640px) {
-            #map { 
-                border-radius: 0;
-                border-left: none;
-                border-right: none;
-            }
+        .map-container {
+            background: var(--bg);
         }
-        .light #map { 
-            border: 1px solid #cbd5e1;
-            box-shadow: 0 0 40px rgba(0, 120, 212, 0.08), 0 4px 20px rgba(0, 0, 0, 0.1);
+        .leaflet-container {
+            background: var(--bg);
+            font-family: 'JetBrains Mono', monospace;
+        }
+        .leaflet-control-attribution {
+            background: rgba(17, 21, 28, 0.7) !important;
+            color: var(--text-dim) !important;
+            font-size: 9px !important;
+            letter-spacing: 0.04em;
+            border-top-left-radius: 4px;
+        }
+        html.light .leaflet-control-attribution {
+            background: rgba(255, 255, 255, 0.8) !important;
+        }
+        .leaflet-control-attribution a { color: var(--text-mute) !important; }
+        .leaflet-control-zoom a {
+            background: var(--bg-elev) !important;
+            color: var(--text) !important;
+            border: 1px solid var(--border) !important;
+        }
+        .leaflet-control-zoom a:hover {
+            background: var(--accent-soft) !important;
+            border-color: var(--accent) !important;
         }
 
         /* Pulse animation for markers */
@@ -73,242 +121,418 @@
             100% { transform: scale(1); opacity: 0.8; }
         }
         
-        /* Header gradient */
-        .header-gradient {
-            background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+        /* === NEW HEADER === */
+        .hud {
+            display: flex;
+            align-items: center;
+            padding: 14px 24px;
+            background: var(--bg-elev);
+            border-bottom: 1px solid var(--border);
+            padding-top: calc(14px + env(safe-area-inset-top));
         }
-        .light .header-gradient {
-            background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
-        }
-
-        /* Select dropdown styling */
-        select {
-            background-color: #1e293b;
-            color: white;
-            transition: border-color 0.2s ease;
-            cursor: pointer;
-        }
-        select:hover {
-            border-color: #00d15f !important;
-        }
-        .light select {
-            background-color: white;
-            color: #0f172a;
-        }
-        .light select:hover {
-            border-color: #0078D4 !important;
-        }
-
-        /* Multi-select dropdown */
-        .multiselect {
+        .brand { display: flex; align-items: center; gap: 14px; }
+        .brand-mark {
+            width: 26px; height: 26px;
             position: relative;
-            display: inline-block;
+            display: flex; align-items: center; justify-content: center;
+            flex-shrink: 0;
         }
-        .multiselect-btn {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
+        .brand-mark::after {
+            content: ''; width: 10px; height: 10px;
+            background: var(--accent); border-radius: 50%;
+            box-shadow: 0 0 14px var(--accent-glow);
+        }
+        .brand-mark::before {
+            content: ''; position: absolute; inset: 4px;
+            border: 1.5px solid var(--accent);
+            border-radius: 50%;
+            opacity: 0.35;
+            animation: brand-pulse 2.4s ease-out infinite;
+        }
+        @keyframes brand-pulse {
+            0% { transform: scale(0.7); opacity: 0.6; }
+            100% { transform: scale(1.6); opacity: 0; }
+        }
+        .brand-text { display: flex; flex-direction: column; gap: 1px; }
+        .brand-text .tag {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 9px; letter-spacing: 0.18em;
+            color: var(--text-dim);
+            text-transform: uppercase;
+        }
+        .brand-text .title {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 700; font-size: 15px;
+            letter-spacing: -0.005em;
+            color: var(--text);
+        }
+        .brand-text .title em { color: var(--accent); font-style: normal; }
+
+        .status {
+            margin-left: 36px;
+            display: flex; align-items: center; gap: 24px;
+            flex: 1;
+            font-size: 11px; color: var(--text-mute);
+            text-transform: uppercase; letter-spacing: 0.12em;
+        }
+        .status .row { display: flex; align-items: baseline; gap: 8px; }
+        .status .row b {
+            font-weight: 500; color: var(--text);
+            font-size: 13px; letter-spacing: 0;
+        }
+
+        .hud .controls { display: flex; align-items: center; gap: 6px; }
+
+        @media (max-width: 900px) {
+            .status { display: none; }
+        }
+        @media (max-width: 640px) {
+            .hud { padding: 10px 14px; gap: 8px; flex-wrap: wrap; }
+            .brand-text .tag { display: none; }
+            .hud .controls { width: 100%; flex-wrap: wrap; gap: 6px; }
+        }
+
+        /* === CONTROLS === */
+        .ctl {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 11px;
+            background: var(--bg-elev);
+            border: 1px solid var(--border-strong);
+            color: var(--text);
+            padding: 7px 12px;
+            border-radius: 6px;
             cursor: pointer;
-            transition: border-color 0.2s ease;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+            display: inline-flex; align-items: center; gap: 7px;
+            transition: border-color 0.15s, background 0.15s, color 0.15s;
+            line-height: 1.2;
         }
-        .multiselect-btn:hover {
-            border-color: #00d15f !important;
+        .ctl.hidden { display: none; }
+        .ctl:hover { border-color: var(--accent); background: var(--accent-soft); }
+        .ctl:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: 1px;
+            border-color: var(--accent);
         }
-        .light .multiselect-btn:hover {
-            border-color: #0078D4 !important;
+        .ctl svg { width: 12px; height: 12px; flex-shrink: 0; }
+        .ctl-icon { padding: 7px 9px; }
+        .ctl-icon svg { width: 14px; height: 14px; }
+        .ctl-search {
+            min-width: 240px;
+            text-transform: none;
+            letter-spacing: 0;
+            font-family: 'JetBrains Mono', monospace;
+            padding-left: 30px;
         }
-        .multiselect-dropdown {
-            position: absolute;
-            top: 100%;
-            left: 0;
-            right: 0;
-            min-width: 180px;
-            margin-top: 4px;
-            background: #1e293b;
-            border: 1px solid #475569;
-            border-radius: 0.5rem;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+        .ctl-search::placeholder { color: var(--text-dim); }
+        .ctl-reset {
+            color: var(--aws);
+            border-color: var(--aws);
+            background: transparent;
+        }
+        .ctl-reset:hover { background: var(--aws); color: var(--bg); }
+
+        .search-container { position: relative; }
+        .search-container .relative { position: relative; display: inline-block; }
+        .search-icon {
+            position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
+            width: 12px; height: 12px;
+            color: var(--text-dim);
+            pointer-events: none;
+        }
+
+        /* Searched results dropdown */
+        #searchResults {
+            position: absolute; top: calc(100% + 4px); left: 0;
+            min-width: 260px; max-height: 320px;
+            overflow-y: auto;
+            background: var(--bg-elev);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.35);
             z-index: 1000;
-            opacity: 0;
-            visibility: hidden;
-            transform: translateY(-8px);
-            transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+            opacity: 0; visibility: hidden; transform: translateY(-4px);
+            transition: opacity 0.15s, visibility 0.15s, transform 0.15s;
         }
-        .multiselect-dropdown.open {
-            opacity: 1;
-            visibility: visible;
-            transform: translateY(0);
+        #searchResults.open { opacity: 1; visibility: visible; transform: translateY(0); }
+        .search-result-item {
+            display: flex; align-items: center; gap: 10px;
+            padding: 8px 12px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 12px;
+            color: var(--text);
+            background: transparent; border: none;
+            border-bottom: 1px solid var(--border);
+            width: 100%; text-align: left; cursor: pointer;
         }
-        .light .multiselect-dropdown {
-            background: white;
-            border-color: #e2e8f0;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+        .search-result-item:last-child { border-bottom: none; }
+        .search-result-item:hover, .search-result-item.highlighted { background: var(--accent-soft); }
+        .search-result-item .provider-dot {
+            width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
         }
+        .search-result-item .region-name { font-weight: 500; color: var(--text); }
+        .search-result-item .match-text { font-size: 10px; color: var(--text-mute); }
+        .search-no-results {
+            padding: 12px; text-align: center; color: var(--text-mute);
+            font-family: 'JetBrains Mono', monospace; font-size: 11px;
+        }
+
+        /* Select element styling */
+        select.ctl {
+            appearance: none;
+            -webkit-appearance: none;
+            background-image: linear-gradient(45deg, transparent 50%, var(--text-mute) 50%),
+                              linear-gradient(135deg, var(--text-mute) 50%, transparent 50%);
+            background-position: calc(100% - 14px) calc(50% - 2px),
+                                 calc(100% - 9px) calc(50% - 2px);
+            background-size: 5px 5px;
+            background-repeat: no-repeat;
+            padding-right: 24px;
+        }
+
+        /* Multi-select */
+        .multiselect { position: relative; display: inline-block; }
+        .multiselect-chevron { transition: transform 0.2s ease; }
+        .multiselect-btn[aria-expanded="true"] .multiselect-chevron { transform: rotate(180deg); }
+        .multiselect-dropdown {
+            position: absolute; top: calc(100% + 4px); right: 0;
+            min-width: 180px; max-width: calc(100vw - 16px);
+            background: var(--bg-elev);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.35);
+            z-index: 1000;
+            opacity: 0; visibility: hidden; transform: translateY(-4px);
+            transition: opacity 0.15s, visibility 0.15s, transform 0.15s;
+            overflow: hidden;
+        }
+        .multiselect-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); }
         .multiselect-option {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            padding: 0.5rem 0.75rem;
+            display: flex; align-items: center; gap: 10px;
+            padding: 9px 12px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 11px;
+            color: var(--text);
             cursor: pointer;
-            transition: background 0.15s ease;
-            font-size: 0.75rem;
+            transition: background 0.12s;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
         }
-        .multiselect-option:first-child {
-            border-radius: 0.5rem 0.5rem 0 0;
-        }
-        .multiselect-option:last-child {
-            border-radius: 0 0 0.5rem 0.5rem;
-        }
-        .multiselect-option:hover {
-            background: #334155;
-        }
-        .light .multiselect-option:hover {
-            background: #f1f5f9;
-        }
+        .multiselect-option:hover { background: var(--accent-soft); }
         .multiselect-option input[type="checkbox"] {
-            accent-color: #00d15f;
-            width: 14px;
-            height: 14px;
+            accent-color: var(--accent);
+            width: 13px; height: 13px;
             cursor: pointer;
         }
-        .multiselect-chevron {
-            transition: transform 0.2s ease;
-        }
-        .multiselect-btn[aria-expanded="true"] .multiselect-chevron {
-            transform: rotate(180deg);
+
+        @media (max-width: 640px) {
+            .ctl-search { min-width: 0; flex: 1; }
+            .ctl .ctl-label { display: none; }
+            .hud .controls .search-container { flex: 1 1 100%; }
+            .hud .controls #providerFilter,
+            .hud .controls .multiselect { flex: 0 1 auto; min-width: 0; }
+            .hud .controls .multiselect-btn { width: 100%; min-width: 0; overflow: hidden; }
+            .hud .controls .multiselect-btn > #serviceFilterLabel {
+                min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+            }
         }
 
-        /* Theme toggle button */
-        #themeToggle {
-            transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
-        }
-        #themeToggle:hover {
-            transform: scale(1.05);
-        }
-        #themeToggle:active {
-            transform: scale(0.95);
-        }
-
-        /* Leaflet popup - dark mode (default and explicit .dark) */
+        /* === LEAFLET POPUP === */
         .leaflet-popup-content-wrapper {
-            background: #1e293b !important;
-            color: white !important;
-            border: 1px solid #475569 !important;
-            padding: 0;
-            border-radius: 0.75rem;
-            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.05) !important;
-            animation: popup-fade-in 0.2s ease-out;
+            background: var(--bg-elev) !important;
+            color: var(--text) !important;
+            border: 1px solid var(--border) !important;
+            padding: 0 !important;
+            border-radius: 10px !important;
+            box-shadow:
+                0 12px 40px rgba(0,0,0,0.5),
+                0 0 0 1px rgba(0,255,136,0.04) !important;
+            overflow: hidden;
         }
-        @keyframes popup-fade-in {
-            from { opacity: 0; transform: translateY(10px) scale(0.95); }
-            to { opacity: 1; transform: translateY(0) scale(1); }
+        html.light .leaflet-popup-content-wrapper {
+            box-shadow:
+                0 12px 40px rgba(15,20,25,0.10),
+                0 0 0 1px rgba(0,128,90,0.04) !important;
         }
         .leaflet-popup-tip {
-            background: #1e293b !important;
-            border: 1px solid #475569 !important;
+            background: var(--bg-elev) !important;
+            border: 1px solid var(--border) !important;
             box-shadow: none !important;
         }
         .leaflet-container a.leaflet-popup-close-button {
-            color: #94a3b8 !important;
-            transition: color 0.2s ease, transform 0.2s ease;
+            color: var(--text-mute) !important;
             font-size: 20px !important;
-            width: 24px !important;
-            height: 24px !important;
+            width: 28px !important;
+            height: 28px !important;
             padding: 4px !important;
+            transition: color 0.2s, transform 0.2s;
+            top: 8px !important;
+            right: 8px !important;
         }
         .leaflet-container a.leaflet-popup-close-button:hover {
-            color: #f87171 !important;
+            color: var(--accent) !important;
             transform: scale(1.1);
         }
-        
-        /* Leaflet popup - light mode */
-        .light .leaflet-popup-content-wrapper {
-            background: white !important;
-            color: #0f172a !important;
-            border: 1px solid #e2e8f0 !important;
-            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.05) !important;
-        }
-        .light .leaflet-popup-tip {
-            background: white !important;
-            border: 1px solid #e2e8f0 !important;
-        }
-        .light .leaflet-container a.leaflet-popup-close-button {
-            color: #64748b !important;
-        }
-        
-        .leaflet-popup-content {
-            margin: 0 !important;
-            width: auto !important;
-        }
-        
-        /* Mobile popup adjustments */
+        .leaflet-popup-content { margin: 0 !important; width: auto !important; }
+
         @media (max-width: 640px) {
-            .leaflet-popup-content-wrapper {
-                max-width: calc(100vw - 40px) !important;
-            }
-            .leaflet-popup {
-                max-width: calc(100vw - 20px) !important;
-            }
-        }
-        
-        /* Popup inner content - light mode overrides */
-        .light .leaflet-popup-content h3 { color: #0f172a !important; }
-        .light .leaflet-popup-content .bg-slate-900\/50,
-        .light .leaflet-popup-content .bg-slate-900\/60 { 
-            background: #f1f5f9 !important; 
-            border-color: #e2e8f0 !important; 
-        }
-        .light .leaflet-popup-content .bg-slate-800,
-        .light .leaflet-popup-content .bg-slate-800\/80 { 
-            background: #ffffff !important; 
-            border-color: #e2e8f0 !important;
-        }
-        .light .leaflet-popup-content .bg-slate-700\/50,
-        .light .leaflet-popup-content .bg-slate-700\/60,
-        .light .leaflet-popup-content .bg-gradient-to-r { 
-            background: #f1f5f9 !important; 
-        }
-        .light .leaflet-popup-content .border-slate-700,
-        .light .leaflet-popup-content .border-slate-700\/50,
-        .light .leaflet-popup-content .border-slate-700\/30 { 
-            border-color: #e2e8f0 !important; 
-        }
-        .light .leaflet-popup-content .text-white { color: #0f172a !important; }
-        .light .leaflet-popup-content .text-slate-300 { color: #334155 !important; }
-        .light .leaflet-popup-content .text-slate-400 { color: #475569 !important; }
-        .light .leaflet-popup-content .text-slate-500 { color: #64748b !important; }
-        
-        /* Light mode service icon wrapper hover */
-        .light .leaflet-popup-content .service-icon-wrapper:hover {
-            background: rgba(0, 0, 0, 0.05) !important;
-        }
-        
-        /* Light mode badge adjustments */
-        .light .leaflet-popup-content .text-green-400 { color: #16a34a !important; }
-        .light .leaflet-popup-content .bg-green-500\/10 { background: rgba(22, 163, 74, 0.1) !important; }
-        .light .leaflet-popup-content .border-green-500\/30 { border-color: rgba(22, 163, 74, 0.3) !important; }
-        .light .leaflet-popup-content .text-blue-400 { color: #2563eb !important; }
-        .light .leaflet-popup-content .bg-blue-500\/10 { background: rgba(37, 99, 235, 0.1) !important; }
-        .light .leaflet-popup-content .border-blue-500\/30 { border-color: rgba(37, 99, 235, 0.3) !important; }
-        .light .leaflet-popup-content .text-amber-400 { color: #d97706 !important; }
-        .light .leaflet-popup-content .bg-amber-500\/10 { background: rgba(217, 119, 6, 0.1) !important; }
-        .light .leaflet-popup-content .border-amber-500\/30 { border-color: rgba(217, 119, 6, 0.3) !important; }
-
-        /* Legend styling */
-        .legend-container {
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
-        }
-        .legend-container:hover {
-            transform: translateY(-2px);
+            .leaflet-popup-content-wrapper { max-width: calc(100vw - 40px) !important; }
+            .leaflet-popup { max-width: calc(100vw - 20px) !important; }
         }
 
-        /* Service icon hover effect */
-        .service-icon-wrapper {
-            transition: transform 0.2s ease;
+        /* Popup inner */
+        .popup-card { width: 360px; max-width: calc(100vw - 40px); font-family: 'JetBrains Mono', monospace; }
+        .popup-head {
+            padding: 14px 16px 12px;
+            border-bottom: 1px solid var(--border);
         }
-        .service-icon-wrapper:hover {
-            transform: scale(1.1);
+        .popup-region-id {
+            font-size: 10px; color: var(--text-mute);
+            letter-spacing: 0.16em; text-transform: uppercase;
         }
+        .popup-region-name {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 19px; font-weight: 700;
+            margin-top: 4px;
+            letter-spacing: -0.01em;
+            color: var(--text);
+        }
+        .popup-region-coord {
+            font-size: 10px; color: var(--text-mute);
+            margin-top: 6px; letter-spacing: 0.04em;
+        }
+        .popup-provider-strip {
+            display: flex; align-items: center; gap: 10px;
+            padding: 9px 16px;
+            background: var(--bg-elev-2);
+            border-bottom: 1px solid var(--border);
+            font-size: 10px;
+            color: var(--text-mute);
+            text-transform: uppercase; letter-spacing: 0.12em;
+        }
+        .popup-provider-strip .pchip {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-weight: 500;
+        }
+        .popup-provider-strip .pchip.azure { color: var(--azure); }
+        .popup-provider-strip .pchip.aws { color: var(--aws); }
+        .popup-provider-strip .pchip svg { width: 11px; height: 11px; }
+        .popup-services { padding: 6px 16px 14px; }
+        .popup-svc {
+            display: grid;
+            grid-template-columns: 16px 1fr auto;
+            align-items: center; gap: 12px;
+            padding: 9px 0;
+            border-bottom: 1px solid var(--border);
+            font-size: 12px;
+        }
+        .popup-svc:last-child { border-bottom: none; }
+        .popup-svc .svc-icon { width: 14px; height: 14px; color: var(--accent); }
+        .popup-svc .name {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 500;
+            color: var(--text);
+            letter-spacing: -0.005em;
+        }
+        .popup-svc .pills {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-end;
+            gap: 4px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 10px;
+            color: var(--text-mute);
+        }
+        .popup-svc .pill {
+            border: 1px solid var(--border-strong);
+            background: var(--bg-elev-2);
+            padding: 3px 7px;
+            border-radius: 4px;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+        }
+        .popup-svc .pill.core {
+            color: var(--accent);
+            border-color: rgba(0, 255, 136, 0.3);
+            background: rgba(0, 255, 136, 0.06);
+        }
+        html.light .popup-svc .pill.core {
+            border-color: rgba(0, 128, 90, 0.3);
+            background: rgba(0, 128, 90, 0.06);
+        }
+        .popup-svc .pill.noncore {
+            color: var(--aws);
+            border-color: rgba(255, 157, 61, 0.3);
+            background: rgba(255, 157, 61, 0.06);
+        }
+        html.light .popup-svc .pill.noncore {
+            border-color: rgba(217, 117, 6, 0.3);
+            background: rgba(217, 117, 6, 0.06);
+        }
+        .popup-svc .available {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 10px;
+            color: var(--text-mute);
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            border: 1px solid var(--border-strong);
+            padding: 3px 7px;
+            border-radius: 4px;
+            background: var(--bg-elev-2);
+        }
+
+        /* Vault tier tooltip — needs the popup wrapper to allow overflow so the bubble can escape */
+        .leaflet-popup-content-wrapper:has(.popup-card) { overflow: visible; }
+        .popup-svc .pill[data-tooltip] { position: relative; cursor: help; }
+        .popup-svc .pill[data-tooltip]:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: 2px;
+        }
+        .popup-svc .pill[data-tooltip]::after {
+            content: attr(data-tooltip);
+            position: absolute;
+            bottom: calc(100% + 8px);
+            left: 50%;
+            transform: translateX(-50%);
+            background: var(--bg-elev-2);
+            color: var(--text);
+            border: 1px solid var(--border-strong);
+            border-radius: 6px;
+            padding: 6px 10px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 10px;
+            font-weight: 400;
+            letter-spacing: 0;
+            text-transform: none;
+            white-space: nowrap;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.12s ease-out;
+            z-index: 1000;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.35);
+        }
+        .popup-svc .pill[data-tooltip]:hover::after,
+        .popup-svc .pill[data-tooltip]:focus-visible::after { opacity: 1; }
+        @media (prefers-reduced-motion: reduce) {
+            .popup-svc .pill[data-tooltip]::after { transition: none; }
+        }
+
+        /* === PROVIDER MARKERS === */
+        .map-marker-dot {
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #ffffff;
+            border: 1px solid var(--border);
+            box-shadow: 0 2px 6px rgba(0,0,0,0.25);
+            transition: transform 0.15s ease;
+        }
+        .map-marker-dot:hover { transform: scale(1.18); }
+        .map-marker-dot svg { width: 16px; height: 16px; }
 
         /* Zoom controls */
         .leaflet-control-zoom a {
@@ -318,46 +542,25 @@
             transform: scale(1.05);
         }
 
-        /* Info panel */
+        /* Info panel slide-out */
         #infoPanel {
             scrollbar-width: thin;
-            scrollbar-color: #475569 transparent;
+            scrollbar-color: var(--border-strong) transparent;
             transform: translateX(100%);
-            transition: transform 0.3s ease-out;
+            transition: transform 0.28s cubic-bezier(0.25, 1, 0.5, 1);
+            background: var(--bg-elev);
+            border-left: 1px solid var(--border);
+            color: var(--text);
+            font-family: 'JetBrains Mono', monospace;
         }
-        #infoPanel::-webkit-scrollbar {
-            width: 6px;
-        }
-        #infoPanel::-webkit-scrollbar-track {
-            background: transparent;
-        }
+        #infoPanel::-webkit-scrollbar { width: 6px; }
+        #infoPanel::-webkit-scrollbar-track { background: transparent; }
         #infoPanel::-webkit-scrollbar-thumb {
-            background: #475569;
+            background: var(--border-strong);
             border-radius: 3px;
         }
-        .light #infoPanel {
-            scrollbar-color: #cbd5e1 transparent;
-        }
-        .light #infoPanel::-webkit-scrollbar-thumb {
-            background: #cbd5e1;
-        }
-        #infoPanelOverlay.open {
-            opacity: 1;
-        }
-        #infoPanel.open {
-            transform: translateX(0);
-        }
-
-        /* Info button hover effect */
-        #infoBtn {
-            transition: transform 0.2s ease;
-        }
-        #infoBtn:hover {
-            transform: scale(1.05);
-        }
-        #infoBtn:active {
-            transform: scale(0.95);
-        }
+        #infoPanel.open { transform: translateX(0); }
+        #infoPanelOverlay.open { opacity: 1; }
 
         /* Custom cluster marker styles */
         .marker-cluster {
@@ -374,76 +577,37 @@
             align-items: center;
             justify-content: center;
             border-radius: 50%;
+            background-color: var(--accent);
+            color: #ffffff;
+            border: 2px solid #ffffff;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
             font-weight: 700;
-            font-size: 12px;
-            color: white;
-            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3), 0 0 0 3px rgba(255, 255, 255, 0.1);
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
             cursor: pointer;
         }
         .cluster-marker:hover {
-            transform: scale(1.15);
-            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4), 0 0 0 4px rgba(255, 255, 255, 0.2);
+            transform: scale(1.1);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45);
+        }
+        html.light .cluster-marker {
+            background-color: var(--accent);
+            color: #ffffff;
+            border-color: #ffffff;
         }
         .cluster-small {
             width: 36px;
             height: 36px;
-            background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
-            border: 2px solid #00d15f;
-            font-size: 11px;
+            font-size: 12px;
         }
         .cluster-medium {
             width: 44px;
             height: 44px;
-            background: linear-gradient(135deg, #065f46 0%, #047857 100%);
-            border: 2px solid #10b981;
-            font-size: 13px;
+            font-size: 14px;
         }
         .cluster-large {
             width: 52px;
             height: 52px;
-            background: linear-gradient(135deg, #047857 0%, #00d15f 100%);
-            border: 3px solid #34d399;
-            font-size: 14px;
-        }
-        /* Provider indicator bar at bottom of cluster */
-        .cluster-providers {
-            position: absolute;
-            bottom: -4px;
-            left: 50%;
-            transform: translateX(-50%);
-            display: flex;
-            gap: 2px;
-            border-radius: 4px;
-            overflow: hidden;
-        }
-        .cluster-providers .azure-bar {
-            height: 4px;
-            background: #0078D4;
-        }
-        .cluster-providers .aws-bar {
-            height: 4px;
-            background: #FF9900;
-        }
-        /* Light mode cluster styles */
-        .light .cluster-small {
-            background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
-            border-color: #16a34a;
-            color: #0f172a;
-            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15), 0 0 0 3px rgba(0, 0, 0, 0.05);
-        }
-        .light .cluster-medium {
-            background: linear-gradient(135deg, #d1fae5 0%, #a7f3d0 100%);
-            border-color: #059669;
-            color: #064e3b;
-        }
-        .light .cluster-large {
-            background: linear-gradient(135deg, #6ee7b7 0%, #34d399 100%);
-            border-color: #047857;
-            color: #022c22;
-        }
-        .light .cluster-marker:hover {
-            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2), 0 0 0 4px rgba(0, 0, 0, 0.1);
+            font-size: 16px;
         }
         /* Cluster spiderfy leg styles */
         .leaflet-cluster-anim .leaflet-marker-icon, .leaflet-cluster-anim .leaflet-marker-shadow {
@@ -473,101 +637,6 @@
             display: flex;
         }
 
-        /* Search input and dropdown */
-        .search-container {
-            position: relative;
-        }
-        #regionSearch {
-            transition: width 0.2s ease;
-            width: 140px;
-        }
-        #regionSearch:focus {
-            width: 200px;
-        }
-        @media (max-width: 640px) {
-            #regionSearch, #regionSearch:focus {
-                width: 120px;
-            }
-        }
-        #searchResults {
-            position: absolute;
-            top: 100%;
-            left: 0;
-            right: 0;
-            min-width: 250px;
-            max-height: 300px;
-            overflow-y: auto;
-            margin-top: 4px;
-            background: #1e293b;
-            border: 1px solid #475569;
-            border-radius: 0.5rem;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
-            z-index: 1000;
-            opacity: 0;
-            visibility: hidden;
-            transform: translateY(-8px);
-            transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
-        }
-        #searchResults.open {
-            opacity: 1;
-            visibility: visible;
-            transform: translateY(0);
-        }
-        .light #searchResults {
-            background: white;
-            border-color: #e2e8f0;
-            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
-        }
-        .search-result-item {
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-            padding: 0.625rem 0.75rem;
-            cursor: pointer;
-            transition: background 0.15s ease;
-            background: transparent;
-            border: none;
-            border-bottom: 1px solid #334155;
-            width: 100%;
-            text-align: left;
-        }
-        .search-result-item:last-child {
-            border-bottom: none;
-        }
-        .search-result-item:hover, .search-result-item.highlighted {
-            background: #334155;
-        }
-        .light .search-result-item {
-            border-bottom-color: #e2e8f0;
-        }
-        .light .search-result-item:hover, .light .search-result-item.highlighted {
-            background: #f1f5f9;
-        }
-        .search-result-item .provider-dot {
-            width: 10px;
-            height: 10px;
-            border-radius: 50%;
-            flex-shrink: 0;
-        }
-        .search-result-item .region-name {
-            font-size: 0.875rem;
-            color: white;
-            font-weight: 500;
-        }
-        .light .search-result-item .region-name {
-            color: #0f172a;
-        }
-        .search-result-item .match-text {
-            font-size: 0.75rem;
-            color: #94a3b8;
-        }
-        .search-no-results {
-            padding: 1rem;
-            text-align: center;
-            color: #94a3b8;
-            font-size: 0.875rem;
-        }
-
         @media (prefers-reduced-motion: reduce) {
             *, *::before, *::after {
                 animation-duration: 0.01ms !important;
@@ -576,127 +645,255 @@
                 scroll-behavior: auto !important;
             }
         }
+
+        /* Overlay panels on the map */
+        .panel-legend {
+            background: rgba(17, 21, 28, 0.92);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 12px 14px;
+            min-width: 170px;
+            backdrop-filter: blur(10px);
+            font-family: 'JetBrains Mono', monospace;
+            transition: transform 0.2s ease;
+        }
+        html.light .panel-legend {
+            background: rgba(255, 255, 255, 0.92);
+        }
+        .panel-legend:hover { transform: translateY(-1px); }
+        .panel-legend .label {
+            font-size: 9px; color: var(--text-dim);
+            letter-spacing: 0.18em; text-transform: uppercase;
+            margin-bottom: 10px;
+        }
+        .panel-legend .row {
+            display: flex; align-items: center; gap: 10px;
+            margin-bottom: 6px;
+            font-size: 11px;
+            color: var(--text);
+        }
+        .panel-legend .row:last-child { margin-bottom: 0; }
+        .panel-legend .row .glyph {
+            width: 14px; height: 14px;
+            display: inline-flex; align-items: center; justify-content: center;
+            flex-shrink: 0;
+        }
+        .panel-legend .row .glyph svg { width: 14px; height: 14px; display: block; }
+        .panel-legend .row .count {
+            margin-left: auto; color: var(--text-mute); font-size: 10px;
+        }
+
+        /* Info panel content */
+        .info-callout {
+            display: flex; gap: 10px;
+            padding: 12px 14px;
+            border-radius: 8px;
+            border: 1px solid var(--accent);
+            background: var(--accent-soft);
+            margin-bottom: 16px;
+        }
+        .info-callout-icon { width: 18px; height: 18px; color: var(--accent); flex-shrink: 0; margin-top: 2px; }
+        .info-callout-title {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--accent);
+            margin-bottom: 4px;
+        }
+        .info-callout-body {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 11px;
+            color: var(--text-mute);
+            line-height: 1.5;
+        }
+        .info-section { margin-bottom: 20px; }
+        .info-section-label {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 10px;
+            color: var(--text-dim);
+            text-transform: uppercase;
+            letter-spacing: 0.18em;
+            margin-bottom: 10px;
+        }
+        .info-section-body {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 14px;
+            color: var(--text);
+            line-height: 1.5;
+        }
+        .info-stats { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 20px; }
+        .info-stat {
+            background: var(--bg-elev-2);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 12px;
+        }
+        .info-stat-num {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 700;
+            font-size: 24px;
+            color: var(--text);
+            letter-spacing: -0.02em;
+        }
+        .info-stat-label {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 10px;
+            color: var(--text-mute);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            margin-top: 4px;
+        }
+        .info-link-group { display: flex; flex-direction: column; gap: 6px; }
+        .info-link {
+            display: flex; align-items: center; gap: 10px;
+            padding: 10px 12px;
+            background: var(--bg-elev-2);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 12px;
+            color: var(--text);
+            text-decoration: none;
+            transition: border-color 0.15s, background 0.15s;
+        }
+        .info-link:hover { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
+        .info-link-icon { width: 16px; height: 16px; flex-shrink: 0; color: var(--text-mute); }
+        .info-link:hover .info-link-icon { color: var(--accent); }
+        .info-link span { flex: 1; }
+        .info-arrow { width: 12px; height: 12px; color: var(--text-dim); }
+        .info-link-card { gap: 12px; padding: 10px 12px; }
+        .info-avatar {
+            width: 32px; height: 32px;
+            border-radius: 50%;
+            background: var(--accent);
+            color: var(--bg);
+            display: flex; align-items: center; justify-content: center;
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 700;
+            font-size: 13px;
+            flex-shrink: 0;
+        }
+        .info-link-name {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 500;
+            font-size: 13px;
+            color: var(--text);
+        }
+        .info-link-sub {
+            font-size: 10px;
+            color: var(--text-mute);
+            margin-top: 2px;
+            letter-spacing: 0.04em;
+        }
+        .info-link-accent .info-link-icon { color: var(--accent); }
+        .info-footer {
+            padding-top: 16px;
+            border-top: 1px solid var(--border);
+            text-align: center;
+        }
+        .info-footer p {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 10px;
+            color: var(--text-dim);
+            margin-bottom: 4px;
+            letter-spacing: 0.04em;
+        }
     </style>
 </head>
-<body class="font-sans antialiased">
+<body class="antialiased">
 <div class="app-container overflow-hidden">
-    <header class="header-gradient border-b border-slate-800/50 light:border-slate-200 flex flex-col justify-center px-3 sm:px-6 lg:px-8 py-2 sm:py-3 flex-shrink-0" style="padding-top: calc(0.5rem + env(safe-area-inset-top));">
-        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4 max-w-[1800px] mx-auto w-full">
-            <div class="flex items-center gap-2 sm:gap-3">
-                <div class="w-8 h-8 sm:w-10 sm:h-10 rounded-lg bg-gradient-to-br from-green-400 to-green-600 flex items-center justify-center shadow-lg shadow-green-500/20 flex-shrink-0">
-                    <svg aria-hidden="true" class="w-5 h-5 sm:w-6 sm:h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/>
+    <header class="hud">
+        <div class="brand">
+            <div class="brand-mark" aria-hidden="true"></div>
+            <div class="brand-text">
+                <span class="tag">VDC // Capability Map</span>
+                <h1 class="title"><em>Veeam</em> Data Cloud Service Map</h1>
+            </div>
+        </div>
+
+        <div class="status">
+            <div class="row" aria-live="polite" aria-atomic="true">Regions <b><span id="visibleCount">0</span>/<span id="totalCount">0</span></b></div>
+            <div class="row" aria-hidden="true">Providers <b id="hudProviderCount">--</b></div>
+            <div class="row" aria-hidden="true">Services <b id="hudServiceCount">--</b></div>
+        </div>
+
+        <div class="controls">
+            <!-- Search input -->
+            <div class="search-container">
+                <div class="relative">
+                    <svg aria-hidden="true" class="search-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
                     </svg>
+                    <input type="text" id="regionSearch" placeholder="Search regions…" autocomplete="off" aria-label="Search regions"
+                            role="combobox" aria-expanded="false" aria-controls="searchResults" aria-autocomplete="list" aria-activedescendant=""
+                            class="ctl ctl-search">
                 </div>
-                <div class="min-w-0">
-                    <h1 class="text-lg sm:text-2xl font-bold truncate">
-                        <span class="bg-gradient-to-r from-green-400 to-emerald-500 bg-clip-text text-transparent">Veeam Data Cloud</span>
-                        <span class="text-white light:text-slate-900"> Service Map</span>
-                    </h1>
-                    <p class="text-[10px] sm:text-xs text-slate-400 light:text-slate-500 tracking-wide hidden sm:block">Interactive Global Availability</p>
+                <div id="searchResults" role="listbox" aria-label="Search results" aria-hidden="true"></div>
+            </div>
+
+            <select id="providerFilter" aria-label="Filter by provider" class="ctl">
+                <option value="all">All Providers</option>
+                <option value="Azure">Azure</option>
+                <option value="AWS">AWS</option>
+            </select>
+
+            <div class="multiselect" id="serviceMultiselect">
+                <button type="button" id="serviceFilterBtn" aria-expanded="false" class="ctl multiselect-btn">
+                    <span id="serviceFilterLabel">All Services</span>
+                    <svg aria-hidden="true" class="multiselect-chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                    </svg>
+                </button>
+                <div class="multiselect-dropdown" id="serviceDropdown" aria-hidden="true">
+                    <label class="multiselect-option"><input type="checkbox" value="vdc_vault"> Vault</label>
+                    <label class="multiselect-option"><input type="checkbox" value="vdc_m365"> M365</label>
+                    <label class="multiselect-option"><input type="checkbox" value="vdc_entra_id"> Entra ID</label>
+                    <label class="multiselect-option"><input type="checkbox" value="vdc_salesforce"> Salesforce</label>
+                    <label class="multiselect-option"><input type="checkbox" value="vdc_azure_backup"> Azure Protection</label>
                 </div>
             </div>
 
-            <div class="flex gap-1.5 sm:gap-2 lg:gap-3 items-center flex-wrap">
-                <!-- Search Input -->
-                <div class="search-container">
-                    <div class="relative">
-                        <svg aria-hidden="true" class="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
-                        </svg>
-                        <input type="text" id="regionSearch" placeholder="Search regions…" autocomplete="off" aria-label="Search regions"
-                                role="combobox"
-                                aria-expanded="false"
-                                aria-controls="searchResults"
-                                aria-autocomplete="list"
-                                aria-activedescendant=""
-                                class="bg-slate-800/80 light:bg-white border border-slate-600/50 light:border-slate-300 rounded-lg pl-8 pr-3 py-1.5 sm:py-2 text-xs sm:text-sm text-white light:text-slate-900 placeholder-slate-400 light:placeholder-slate-500 focus:ring-2 focus:ring-green-500/50 focus:border-green-500 outline-none shadow-sm backdrop-blur-sm">
-                    </div>
-                    <div id="searchResults" role="listbox" aria-label="Search results" aria-hidden="true"></div>
-                </div>
+            <button id="resetFilters" aria-label="Reset all filters" class="ctl ctl-reset hidden" title="Reset all filters">
+                <svg aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                </svg>
+                <span class="ctl-label">Reset</span>
+            </button>
 
-                <select id="providerFilter" aria-label="Filter by provider" class="bg-slate-800/80 light:bg-white border border-slate-600/50 light:border-slate-300 rounded-lg px-2 sm:px-3 py-1.5 sm:py-2 text-xs sm:text-sm text-white light:text-slate-900 focus:ring-2 focus:ring-green-500/50 focus:border-green-500 outline-none shadow-sm backdrop-blur-sm min-w-0">
-                    <option value="all">All Providers</option>
-                    <option value="Azure">Azure</option>
-                    <option value="AWS">AWS</option>
-                </select>
+            <button id="themeToggle" aria-label="Toggle theme" class="ctl ctl-icon" title="Toggle theme">
+                <svg id="iconSystem" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/>
+                </svg>
+                <svg id="iconLight" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" class="hidden">
+                    <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"/>
+                </svg>
+                <svg id="iconDark" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" class="hidden">
+                    <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
+                </svg>
+            </button>
 
-                <div class="multiselect" id="serviceMultiselect">
-                    <button type="button" id="serviceFilterBtn" aria-expanded="false" class="multiselect-btn bg-slate-800/80 light:bg-white border border-slate-600/50 light:border-slate-300 rounded-lg px-2 sm:px-3 py-1.5 sm:py-2 text-xs sm:text-sm text-white light:text-slate-900 shadow-sm backdrop-blur-sm min-w-0">
-                        <span id="serviceFilterLabel">All Services</span>
-                        <svg aria-hidden="true" class="multiselect-chevron w-3 h-3 sm:w-4 sm:h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-                        </svg>
-                    </button>
-                    <div class="multiselect-dropdown" id="serviceDropdown" aria-hidden="true">
-                        <label class="multiselect-option text-white light:text-slate-900">
-                            <input type="checkbox" value="vdc_vault"> Vault
-                        </label>
-                        <label class="multiselect-option text-white light:text-slate-900">
-                            <input type="checkbox" value="vdc_m365"> M365
-                        </label>
-                        <label class="multiselect-option text-white light:text-slate-900">
-                            <input type="checkbox" value="vdc_entra_id"> Entra ID
-                        </label>
-                        <label class="multiselect-option text-white light:text-slate-900">
-                            <input type="checkbox" value="vdc_salesforce"> Salesforce
-                        </label>
-                        <label class="multiselect-option text-white light:text-slate-900">
-                            <input type="checkbox" value="vdc_azure_backup"> Azure
-                        </label>
-                    </div>
-                </div>
-
-                <div id="regionCount" class="hidden sm:flex items-center gap-1.5 px-3 py-1.5 bg-slate-800/60 light:bg-slate-100 rounded-lg border border-slate-600/30 light:border-slate-300 text-xs text-slate-300 light:text-slate-600">
-                    <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-                    </svg>
-                    <span><span id="visibleCount" class="font-semibold text-white light:text-slate-900">0</span> of <span id="totalCount" class="font-semibold">0</span> regions</span>
-                </div>
-
-                <button id="resetFilters" aria-label="Reset all filters" class="hidden items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-amber-500/20 light:bg-amber-100 border border-amber-500/40 light:border-amber-400 text-amber-400 light:text-amber-700 hover:bg-amber-500/30 light:hover:bg-amber-200 text-xs font-medium transition-colors duration-200 flex-shrink-0" title="Reset all filters">
-                    <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-                    </svg>
-                    <span class="hidden sm:inline">Reset</span>
-                </button>
-
-                <button id="themeToggle" aria-label="Toggle theme" class="p-2 sm:p-2.5 rounded-lg bg-slate-800/80 light:bg-white border border-slate-600/50 light:border-slate-300 hover:bg-slate-700 light:hover:bg-slate-100 hover:border-green-500/50 shadow-sm backdrop-blur-sm flex-shrink-0" title="Toggle theme">
-                    <svg id="iconSystem" aria-hidden="true" class="w-4 h-4 sm:w-5 sm:h-5 text-slate-300 light:text-slate-600" fill="currentColor" viewBox="0 0 20 20">
-                        <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/>
-                    </svg>
-                    <svg id="iconLight" aria-hidden="true" class="w-4 h-4 sm:w-5 sm:h-5 text-yellow-400 hidden" fill="currentColor" viewBox="0 0 20 20">
-                        <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"/>
-                    </svg>
-                    <svg id="iconDark" aria-hidden="true" class="w-4 h-4 sm:w-5 sm:h-5 text-slate-300 hidden" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
-                    </svg>
-                </button>
-
-                <button id="infoBtn" class="p-2 sm:p-2.5 rounded-lg bg-slate-800/80 light:bg-white border border-slate-600/50 light:border-slate-300 hover:bg-slate-700 light:hover:bg-slate-100 hover:border-green-500/50 shadow-sm backdrop-blur-sm flex-shrink-0" title="About this map" aria-label="Open about panel" aria-expanded="false" aria-controls="infoPanel">
-                    <svg class="w-4 h-4 sm:w-5 sm:h-5 text-slate-300 light:text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                    </svg>
-                </button>
-            </div>
+            <button id="infoBtn" class="ctl ctl-icon" title="About this map" aria-label="Open about panel" aria-expanded="false" aria-controls="infoPanel">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+            </button>
         </div>
     </header>
 
-    <div class="map-container p-0 sm:p-4 lg:p-6 bg-gradient-to-b from-slate-950 to-slate-900 light:from-slate-100 light:to-slate-50 transition-colors duration-300 relative">
+    <div class="map-container bg-[var(--bg)] transition-colors duration-300 relative">
         <div id="map"></div>
         
-        <div id="mapLoading" class="absolute inset-0 sm:m-4 lg:m-6 flex items-center justify-center bg-slate-900/90 light:bg-slate-100/90 backdrop-blur-sm rounded-xl z-[1000]">
+        <div id="mapLoading" class="absolute inset-0 flex items-center justify-center z-[1000]" style="background: rgba(10, 13, 18, 0.92); backdrop-filter: blur(4px);">
             <div class="flex flex-col items-center gap-3">
-                <svg aria-hidden="true" class="loading-spinner w-10 h-10 text-green-500" fill="none" viewBox="0 0 24 24">
+                <svg aria-hidden="true" class="loading-spinner w-10 h-10" style="color: var(--accent);" fill="none" viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>
-                <span class="text-slate-300 light:text-slate-600 text-sm font-medium">Loading map…</span>
+                <span style="color: var(--text-mute); font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase;">Loading…</span>
             </div>
         </div>
-        
-        <div id="mapError" class="absolute inset-0 sm:m-4 lg:m-6 items-center justify-center bg-slate-900 light:bg-slate-100 rounded-xl z-[1000]">
+
+        <div id="mapError" class="absolute inset-0 items-center justify-center z-[1000]" style="background: rgba(10, 13, 18, 0.92); backdrop-filter: blur(4px);">
             <div class="flex flex-col items-center gap-4 p-6 text-center">
                 <div class="w-16 h-16 rounded-full bg-red-500/10 flex items-center justify-center">
                     <svg aria-hidden="true" class="w-8 h-8 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -704,8 +901,8 @@
                     </svg>
                 </div>
                 <div>
-                    <h3 class="text-lg font-semibold text-white light:text-slate-900 mb-1">Failed to Load Map</h3>
-                    <p class="text-slate-400 light:text-slate-500 text-sm max-w-xs">The map failed to load. Please check your internet connection and try refreshing the page.</p>
+                    <h3 class="text-lg font-semibold mb-1" style="color: var(--text)">Failed to Load Map</h3>
+                    <p class="text-sm max-w-xs" style="color: var(--text-mute)">The map failed to load. Please check your internet connection and try refreshing the page.</p>
                 </div>
                 <button onclick="location.reload()" class="px-4 py-2 bg-green-600 hover:bg-green-700 text-white text-sm font-medium rounded-lg transition-colors">
                     Refresh Page
@@ -717,128 +914,99 @@
 
 <div id="infoPanelOverlay" class="fixed inset-0 bg-black/50 backdrop-blur-sm z-[2000] hidden opacity-0 transition-opacity duration-300"></div>
 
-<div id="infoPanel" class="fixed top-0 right-0 h-full w-full sm:w-96 max-w-full bg-slate-900 light:bg-white border-l border-slate-700 light:border-slate-200 shadow-2xl z-[2001] overflow-y-auto" role="dialog" aria-modal="true" aria-labelledby="infoPanelTitle">
-    <div class="p-4 sm:p-5">
+<div id="infoPanel" class="fixed top-0 right-0 h-full w-full sm:w-96 max-w-full shadow-2xl z-[2001] overflow-y-auto" role="dialog" aria-modal="true" aria-labelledby="infoPanelTitle">
+    <div class="p-5" style="padding-top: calc(1.25rem + env(safe-area-inset-top));">
         <div class="flex items-center justify-between mb-4">
-            <h2 id="infoPanelTitle" class="text-xl font-bold text-white light:text-slate-900">About This Map</h2>
-            <button id="closeInfoPanel" class="p-2 rounded-lg hover:bg-slate-800 light:hover:bg-slate-100 transition-colors" aria-label="Close panel">
-                <svg aria-hidden="true" class="w-5 h-5 text-slate-400 light:text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <h2 id="infoPanelTitle" class="font-bold" style="font-family: 'Space Grotesk', sans-serif; font-size: 22px; letter-spacing: -0.01em;">About This Map</h2>
+            <button id="closeInfoPanel" class="ctl ctl-icon" aria-label="Close panel">
+                <svg aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
                 </svg>
             </button>
         </div>
 
-        <div class="bg-amber-500/10 border border-amber-500/30 rounded-lg p-3 mb-4">
-            <div class="flex gap-2.5">
-                <svg aria-hidden="true" class="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
-                </svg>
+        <div class="info-callout">
+            <svg aria-hidden="true" class="info-callout-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+            </svg>
+            <div>
+                <p class="info-callout-title">Community Project</p>
+                <p class="info-callout-body">This is an unofficial, community-maintained project. Not affiliated with or endorsed by Veeam Software. Data may be incomplete or outdated.</p>
+            </div>
+        </div>
+
+        <div class="info-section">
+            <h3 class="info-section-label">What is this?</h3>
+            <p class="info-section-body">An interactive map visualizing Veeam Data Cloud (VDC) service availability across AWS and Azure regions. Quickly find where services like Veeam Data Cloud Vault, Microsoft 365 Protection, and more are available.</p>
+        </div>
+
+        <div class="info-stats">
+            <div class="info-stat">
+                <div class="info-stat-num" id="infoTotalRegions">0</div>
+                <div class="info-stat-label">Total Regions</div>
+            </div>
+            <div class="info-stat">
+                <div class="info-stat-num">5</div>
+                <div class="info-stat-label">Services Tracked</div>
+            </div>
+        </div>
+
+        <div class="info-section">
+            <h3 class="info-section-label">Maintained By</h3>
+            <a href="https://github.com/comnam90" target="_blank" rel="noopener noreferrer" class="info-link info-link-card">
+                <div class="info-avatar">C</div>
                 <div>
-                    <p class="text-amber-400 font-semibold text-sm">Community Project</p>
-                    <p class="text-slate-400 light:text-slate-500 text-xs mt-1">This is an unofficial, community-maintained project. Not affiliated with or endorsed by Veeam Software. Data may be incomplete or outdated.</p>
+                    <div class="info-link-name">@comnam90</div>
+                    <div class="info-link-sub">GitHub</div>
                 </div>
-            </div>
-        </div>
-
-        <div class="mb-4">
-            <h3 class="text-sm font-semibold text-slate-400 light:text-slate-500 uppercase tracking-wider mb-2">What is this?</h3>
-            <p class="text-slate-300 light:text-slate-600 text-sm leading-relaxed">
-                An interactive map visualizing Veeam Data Cloud (VDC) service availability across AWS and Azure regions. Quickly find where services like VDC Vault, M365 Protection, and more are available.
-            </p>
-        </div>
-
-        <div class="grid grid-cols-2 gap-2.5 mb-4">
-            <div class="bg-slate-800/50 light:bg-slate-100 rounded-lg p-3 border border-slate-700/50 light:border-slate-200">
-                <div class="text-2xl font-bold text-white light:text-slate-900" id="infoTotalRegions">0</div>
-                <div class="text-xs text-slate-400 light:text-slate-500">Total Regions</div>
-            </div>
-            <div class="bg-slate-800/50 light:bg-slate-100 rounded-lg p-3 border border-slate-700/50 light:border-slate-200">
-                <div class="text-2xl font-bold text-white light:text-slate-900">5</div>
-                <div class="text-xs text-slate-400 light:text-slate-500">Services Tracked</div>
-            </div>
-        </div>
-
-        <div class="mb-4">
-            <h3 class="text-sm font-semibold text-slate-400 light:text-slate-500 uppercase tracking-wider mb-2">Maintained By</h3>
-            <a href="https://github.com/comnam90" target="_blank" rel="noopener noreferrer" class="flex items-center gap-3 p-2.5 rounded-lg bg-slate-800/50 light:bg-slate-100 border border-slate-700/50 light:border-slate-200 hover:border-green-500/50 transition-colors group">
-                <div class="w-9 h-9 rounded-full bg-gradient-to-br from-green-400 to-emerald-600 flex items-center justify-center text-white font-bold text-sm">C</div>
-                <div>
-                    <div class="text-white light:text-slate-900 font-medium group-hover:text-green-400 transition-colors">@comnam90</div>
-                    <div class="text-xs text-slate-400 light:text-slate-500">GitHub</div>
-                </div>
-                <svg aria-hidden="true" class="w-4 h-4 text-slate-500 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
-                </svg>
+                <svg aria-hidden="true" class="info-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
             </a>
         </div>
 
-        <div class="mb-4">
-            <h3 class="text-sm font-semibold text-slate-400 light:text-slate-500 uppercase tracking-wider mb-2">Quick Links</h3>
-            <div class="space-y-1.5">
-                <a href="https://github.com/comnam90/veeam-data-cloud-services-map" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2.5 p-2.5 rounded-lg bg-slate-800/50 light:bg-slate-100 border border-slate-700/50 light:border-slate-200 hover:border-green-500/50 transition-colors group">
-                    <svg aria-hidden="true" class="w-5 h-5 text-slate-400 group-hover:text-green-400 transition-colors" fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-                    </svg>
-                    <span class="text-slate-300 light:text-slate-600 text-sm group-hover:text-green-400 transition-colors">View on GitHub</span>
-                    <svg aria-hidden="true" class="w-4 h-4 text-slate-500 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
-                    </svg>
+        <div class="info-section">
+            <h3 class="info-section-label">Quick Links</h3>
+            <div class="info-link-group">
+                <a href="https://github.com/comnam90/veeam-data-cloud-services-map" target="_blank" rel="noopener noreferrer" class="info-link">
+                    <svg aria-hidden="true" class="info-link-icon" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                    <span>View on GitHub</span>
+                    <svg aria-hidden="true" class="info-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
                 </a>
-                <a href="/api/docs" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2.5 p-2.5 rounded-lg bg-slate-800/50 light:bg-slate-100 border border-slate-700/50 light:border-slate-200 hover:border-green-500/50 transition-colors group">
-                    <svg aria-hidden="true" class="w-5 h-5 text-slate-400 group-hover:text-green-400 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
-                    </svg>
-                    <span class="text-slate-300 light:text-slate-600 text-sm group-hover:text-green-400 transition-colors">API Documentation</span>
-                    <svg aria-hidden="true" class="w-4 h-4 text-slate-500 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
-                    </svg>
+                <a href="/api/docs" target="_blank" rel="noopener noreferrer" class="info-link">
+                    <svg aria-hidden="true" class="info-link-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg>
+                    <span>API Documentation</span>
+                    <svg aria-hidden="true" class="info-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
                 </a>
-                <a href="https://www.veeam.com/products/veeam-data-cloud.html" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2.5 p-2.5 rounded-lg bg-slate-800/50 light:bg-slate-100 border border-slate-700/50 light:border-slate-200 hover:border-green-500/50 transition-colors group">
-                    <svg aria-hidden="true" class="w-5 h-5 text-green-500" fill="currentColor" viewBox="0 0 144 144">
-                        <path d="M118.21 117.2c0 .49-.2.94-.53 1.27-.33.32-.77.53-1.27.53l-21.51.11v12.01H105c3.21 0 6.3-1.28 8.57-3.55l13.2-13.2c2.27-2.27 3.55-5.36 3.55-8.57V94.65h-12.11v22.56zM25.79 26.8c0-.49.2-.94.53-1.27.32-.32.77-.53 1.27-.53l21.51-.11V12.88H39c-3.21 0-6.3 1.28-8.57 3.55l-13.2 13.2a12.14 12.14 0 0 0-3.55 8.57v11.15h12.11V26.79zm-.47 90.68a1.8 1.8 0 0 1-.52-1.27l-.11-21.51H12.68v10.1c0 3.21 1.28 6.3 3.55 8.57l13.2 13.2c2.27 2.27 5.36 3.55 8.57 3.55h11.15v-12.11H26.59c-.49-.01-.94-.21-1.27-.54zm102.46-86.86-13.2-13.2a12.14 12.14 0 0 0-8.57-3.55H94.86v12.11h22.56c.49.01.94.21 1.27.54.32.32.52.77.52 1.27l.11 21.51h12.01V39.2c0-3.21-1.28-6.3-3.55-8.57zM71.86 78.79a6.65 6.65 0 1 0 0-13.3 6.65 6.65 0 0 0 0 13.3"/>
-                    </svg>
-                    <span class="text-slate-300 light:text-slate-600 text-sm group-hover:text-green-400 transition-colors">Official Veeam Data Cloud</span>
-                    <svg aria-hidden="true" class="w-4 h-4 text-slate-500 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
-                    </svg>
+                <a href="https://www.veeam.com/products/veeam-data-cloud.html" target="_blank" rel="noopener noreferrer" class="info-link">
+                    <svg aria-hidden="true" class="info-link-icon" style="color: var(--accent);" fill="currentColor" viewBox="0 0 144 144"><path d="M118.21 117.2c0 .49-.2.94-.53 1.27-.33.32-.77.53-1.27.53l-21.51.11v12.01H105c3.21 0 6.3-1.28 8.57-3.55l13.2-13.2c2.27-2.27 3.55-5.36 3.55-8.57V94.65h-12.11v22.56zM25.79 26.8c0-.49.2-.94.53-1.27.32-.32.77-.53 1.27-.53l21.51-.11V12.88H39c-3.21 0-6.3 1.28-8.57 3.55l-13.2 13.2a12.14 12.14 0 0 0-3.55 8.57v11.15h12.11V26.79zm-.47 90.68a1.8 1.8 0 0 1-.52-1.27l-.11-21.51H12.68v10.1c0 3.21 1.28 6.3 3.55 8.57l13.2 13.2c2.27 2.27 5.36 3.55 8.57 3.55h11.15v-12.11H26.59c-.49-.01-.94-.21-1.27-.54zm102.46-86.86-13.2-13.2a12.14 12.14 0 0 0-8.57-3.55H94.86v12.11h22.56c.49.01.94.21 1.27.54.32.32.52.77.52 1.27l.11 21.51h12.01V39.2c0-3.21-1.28-6.3-3.55-8.57zM71.86 78.79a6.65 6.65 0 1 0 0-13.3 6.65 6.65 0 0 0 0 13.3"/></svg>
+                    <span>Official Veeam Data Cloud</span>
+                    <svg aria-hidden="true" class="info-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
                 </a>
             </div>
         </div>
 
-        <div class="mb-4">
-            <h3 class="text-sm font-semibold text-slate-400 light:text-slate-500 uppercase tracking-wider mb-2">Found an Issue?</h3>
-            <div class="space-y-1.5">
-                <a href="https://github.com/comnam90/veeam-data-cloud-services-map/issues/new?template=missing-service.yml" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2.5 p-2.5 rounded-lg bg-blue-500/10 border border-blue-500/30 hover:bg-blue-500/20 transition-colors group">
-                    <svg aria-hidden="true" class="w-5 h-5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                    </svg>
-                    <span class="text-blue-400 text-sm font-medium">Report Missing Service</span>
+        <div class="info-section">
+            <h3 class="info-section-label">Found an Issue?</h3>
+            <div class="info-link-group">
+                <a href="https://github.com/comnam90/veeam-data-cloud-services-map/issues/new?template=missing-service.yml" target="_blank" rel="noopener noreferrer" class="info-link info-link-accent">
+                    <svg aria-hidden="true" class="info-link-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                    <span>Report Missing Service</span>
                 </a>
-                <a href="https://github.com/comnam90/veeam-data-cloud-services-map/issues/new?template=missing-region.yml" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2.5 p-2.5 rounded-lg bg-purple-500/10 border border-purple-500/30 hover:bg-purple-500/20 transition-colors group">
-                    <svg aria-hidden="true" class="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-                    </svg>
-                    <span class="text-purple-400 text-sm font-medium">Report Missing Region</span>
+                <a href="https://github.com/comnam90/veeam-data-cloud-services-map/issues/new?template=missing-region.yml" target="_blank" rel="noopener noreferrer" class="info-link info-link-accent">
+                    <svg aria-hidden="true" class="info-link-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+                    <span>Report Missing Region</span>
                 </a>
-                <a href="https://github.com/comnam90/veeam-data-cloud-services-map/issues/new?template=incorrect-information.yml" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2.5 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/30 hover:bg-amber-500/20 transition-colors group">
-                    <svg aria-hidden="true" class="w-5 h-5 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
-                    </svg>
-                    <span class="text-amber-400 text-sm font-medium">Report Incorrect Info</span>
+                <a href="https://github.com/comnam90/veeam-data-cloud-services-map/issues/new?template=incorrect-information.yml" target="_blank" rel="noopener noreferrer" class="info-link info-link-accent">
+                    <svg aria-hidden="true" class="info-link-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+                    <span>Report Incorrect Info</span>
                 </a>
             </div>
         </div>
 
-        <div class="pt-3 border-t border-slate-700/50 light:border-slate-200">
+        <div class="info-footer">
             {{ with .GitInfo }}
-            <p class="text-xs text-slate-400 light:text-slate-500 text-center mb-2">
-                Last updated: {{ now.Format "January 2, 2006" }}
-            </p>
+            <p>Last updated: {{ now.Format "January 2, 2006" }}</p>
             {{ end }}
-            <p class="text-xs text-slate-500 light:text-slate-400 text-center">
-                Built with Hugo, Leaflet.js & Tailwind CSS
-            </p>
+            <p>Built with Hugo, Leaflet.js &amp; Tailwind CSS</p>
         </div>
     </div>
 </div>
@@ -908,35 +1076,38 @@
 
         if (DEBUG) console.log("Processed Regions Data:", regions);
 
-        function getServiceIcon(serviceKey) {
-            const icons = {
-                'vdc_entra_id': `<svg aria-hidden="true" class="w-6 h-6" viewBox="0 0 20 20"><path fill="#225086" d="M4.802 15.032c.388.242 1.033.511 1.715.511.621 0 1.198-.18 1.676-.487h.002L10 13.928v4.073a1.56 1.56 0 0 1-.824-.234z"></path><path fill="#6df" d="m8.853 2.507-7.5 8.46c-.579.654-.428 1.642.323 2.111l3.126 1.954c.388.242 1.033.511 1.715.511.621 0 1.198-.18 1.676-.487h.002L10 13.928 5.636 11.2l4.365-4.924V2c-.424 0-.848.169-1.148.507"></path><path fill="#cbf8ff" d="m5.636 11.199.052.032L10 13.927V6.276z"></path><path fill="#074793" d="M18.324 13.078c.751-.469.902-1.457.323-2.111l-4.921-5.551a3.1 3.1 0 0 0-1.313-.291c-.925 0-1.752.399-2.302 1.026l-.109.123 4.364 4.924-4.365 2.728v4.073c.287 0 .573-.078.823-.234l7.5-4.688Z"></path><path fill="#0294e4" d="M10.001 2v4.275l.109-.123a3.05 3.05 0 0 1 2.302-1.026c.472 0 .916.107 1.313.291l-2.579-2.909A1.52 1.52 0 0 0 10 2.001z"></path><path fill="#96bcc2" d="m14.365 11.199-4.364-4.923v7.65z"></path></svg>`,
-                'vdc_m365': `<svg aria-hidden="true" class="w-6 h-6" viewBox="0 0 20 20"><radialGradient id="m365_a" cx="-235.67" cy="-976.437" r="0.242" gradientTransform="matrix(-17.55009 46.87 -81.74998 -30.6106 -83952.58 -18838.056)" gradientUnits="userSpaceOnUse"><stop offset="0.06" stop-color="#ae7fe2"></stop><stop offset="1" stop-color="#0078d4"></stop></radialGradient><radialGradient id="m365_c" cx="-231.163" cy="-948.32" r="0.242" gradientTransform="rotate(-8.37 194093.408 -88191.206)scale(46.576 30.768)" gradientUnits="userSpaceOnUse"><stop offset="0.13" stop-color="#d59dff"></stop><stop offset="1" stop-color="#5e438f"></stop></radialGradient><radialGradient id="m365_e" cx="-259.845" cy="-974.124" r="0.242" gradientTransform="rotate(-165.77 -1022.606 -31253.357)scale(37.387 62.931)" gradientUnits="userSpaceOnUse"><stop offset="0.06" stop-color="#50e6ff"></stop><stop offset="1" stop-color="#436dcd"></stop></radialGradient><linearGradient id="m365_b" x1="9.93" x2="8.198" y1="13.718" y2="10.726" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#114a8b"></stop><stop offset="1" stop-color="#0078d4" stop-opacity="0"></stop></linearGradient><linearGradient id="m365_d" x1="14.178" x2="12.323" y1="9.266" y2="11.927" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#493474"></stop><stop offset="1" stop-color="#8c66ba" stop-opacity="0"></stop></linearGradient><linearGradient id="m365_g" x1="7.446" x2="10.175" y1="7.272" y2="7.272" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#2d3f80"></stop><stop offset="1" stop-color="#436dcd" stop-opacity="0"></stop></linearGradient><path fill="url(#m365_a)" d="m8.577 2.374-.082.048a3 3 0 0 0-.366.262l.242-.165h2l.356 2.754-1.818 1.818-1.818 1.263v1.454c0 1.018.532 1.962 1.403 2.489l1.915 1.159-4.046 2.361h-.781l-1.454-.88a2.91 2.91 0 0 1-1.401-2.489V7.549c0-1.018.532-1.962 1.403-2.489l4.363-2.64.082-.046z"></path><path fill="url(#m365_b)" d="m8.577 2.374-.082.048a3 3 0 0 0-.366.262l.242-.165h2l.356 2.754-1.818 1.818-1.818 1.263v1.454c0 1.018.532 1.962 1.403 2.489l1.915 1.159-4.046 2.361h-.781l-1.454-.88a2.91 2.91 0 0 1-1.401-2.489V7.549c0-1.018.532-1.962 1.403-2.489l4.363-2.64.082-.046z"></path><path fill="url(#m365_c)" d="M12.909 8.182v1.629a2.91 2.91 0 0 1-1.403 2.489l-4.363 2.642c-.89.538-1.998.56-2.909.058l4.261 2.579a2.91 2.91 0 0 0 3.013 0l4.363-2.642a2.91 2.91 0 0 0 1.401-2.489v-1.176l-.364-.545z"></path><path fill="url(#m365_d)" d="M12.909 8.182v1.629a2.91 2.91 0 0 1-1.403 2.489l-4.363 2.642c-.89.538-1.998.56-2.909.058l4.261 2.579a2.91 2.91 0 0 0 3.013 0l4.363-2.642a2.91 2.91 0 0 0 1.401-2.489v-1.176l-.364-.545z"></path><path fill="url(#m365_e)" d="m15.868 5.06-4.363-2.64a2.91 2.91 0 0 0-2.923-.051l-.087.053a2.91 2.91 0 0 0-1.403 2.487v3.449l1.403-.848a2.91 2.91 0 0 1 3.011 0l4.363 2.64a2.9 2.9 0 0 1 1.403 2.395V7.549a2.91 2.91 0 0 0-1.403-2.489z"></path><g fill="url(#m365_g)"><path d="m15.868 5.06-4.363-2.64a2.91 2.91 0 0 0-2.923-.051l-.087.053a2.91 2.91 0 0 0-1.403 2.487v3.449l1.403-.848a2.91 2.91 0 0 1 3.011 0l4.363 2.64a2.9 2.9 0 0 1 1.403 2.395V7.549a2.91 2.91 0 0 0-1.403-2.489z"></path><path d="m15.868 5.06-4.363-2.64a2.91 2.91 0 0 0-2.923-.051l-.087.053a2.91 2.91 0 0 0-1.403 2.487v3.449l1.403-.848a2.91 2.91 0 0 1 3.011 0l4.363 2.64a2.9 2.9 0 0 1 1.403 2.395V7.549a2.91 2.91 0 0 0-1.403-2.489z"></path></g></svg>`, 
-                'vdc_vault': `<svg aria-hidden="true" class="w-6 h-6" fill="#00d15f" viewBox="0 0 144 144"><path d="M118.21 117.2c0 .49-.2.94-.53 1.27-.33.32-.77.53-1.27.53l-21.51.11v12.01H105c3.21 0 6.3-1.28 8.57-3.55l13.2-13.2c2.27-2.27 3.55-5.36 3.55-8.57V94.65h-12.11v22.56zM25.79 26.8c0-.49.2-.94.53-1.27.32-.32.77-.53 1.27-.53l21.51-.11V12.88H39c-3.21 0-6.3 1.28-8.57 3.55l-13.2 13.2a12.14 12.14 0 0 0-3.55 8.57v11.15h12.11V26.79zm-.47 90.68a1.8 1.8 0 0 1-.52-1.27l-.11-21.51H12.68v10.1c0 3.21 1.28 6.3 3.55 8.57l13.2 13.2c2.27 2.27 5.36 3.55 8.57 3.55h11.15v-12.11H26.59c-.49-.01-.94-.21-1.27-.54zm102.46-86.86-13.2-13.2a12.14 12.14 0 0 0-8.57-3.55H94.86v12.11h22.56c.49.01.94.21 1.27.54.32.32.52.77.52 1.27l.11 21.51h12.01V39.2c0-3.21-1.28-6.3-3.55-8.57zM71.86 78.79a6.65 6.65 0 1 0 0-13.3 6.65 6.65 0 0 0 0 13.3"></path><path d="m96.29 39.3-8.4 8.4c-4.64-3.09-10.21-4.9-16.19-4.9s-11.26 1.72-15.82 4.66l-8.16-8.16-8.41 8.41 8.08 8.08c-3.14 4.66-4.97 10.28-4.97 16.31s1.81 11.55 4.9 16.19l-8 8 8.41 8.41 8.04-8.04c4.59 2.99 10.07 4.74 15.94 4.74s11.64-1.83 16.31-4.97l8.28 8.28 8.41-8.41-8.37-8.37c2.94-4.57 4.66-10 4.66-15.82s-1.75-11.35-4.74-15.94l8.45-8.45-8.41-8.41zm-8.46 40.13a17.8 17.8 0 0 1-5.67 6.96s-.01 0-.02.01c-.4.29-.81.57-1.23.82l-.04.02c-.43.26-.86.5-1.31.72a17.6 17.6 0 0 1-7.86 1.86c-2.66 0-5.19-.61-7.46-1.67-3.7-1.72-6.7-4.67-8.48-8.33-1.14-2.34-1.8-4.96-1.8-7.74s.68-5.49 1.86-7.86c.22-.45.46-.88.72-1.31 0-.01.02-.03.03-.04.26-.42.53-.83.82-1.23 0 0 0-.01.01-.02 1.79-2.44 4.18-4.4 6.96-5.67 2.24-1.02 4.72-1.61 7.34-1.61 2.78 0 5.4.66 7.74 1.8 3.66 1.79 6.61 4.79 8.33 8.48 1.06 2.27 1.67 4.79 1.67 7.46s-.59 5.1-1.61 7.34z"></path></svg>`, 
-                'vdc_salesforce': `<svg aria-hidden="true" class="w-6 h-6" viewBox="0 0 273 191"><g fill="none"><path fill="#0d9dda" d="M113.3 21.2c8.8-9.1 21-14.8 34.5-14.8 18 0 33.6 10 42 24.9 7.3-3.2 15.3-5 23.7-5 32.4 0 58.7 26.5 58.7 59.2s-26.3 59.2-58.7 59.2c-4 0-7.8-.4-11.6-1.2-7.3 13.1-21.4 22-37.4 22-6.7 0-13.1-1.6-18.8-4.3-7.5 17.5-24.8 29.8-45 29.8-21.1 0-39-13.3-45.9-32-3 .6-6.1 1-9.3 1C20.4 160 .1 139.4.1 114.1c0-17 9.1-31.8 22.7-39.8-2.8-6.4-4.3-13.5-4.3-21C18.5 24.1 42.2.5 71.4.5c17 0 32.2 8.1 41.9 20.7"></path><g fill="#fff"><path d="M39.4 99.3c-.2.4.1.5.1.6.5.4 1 .6 1.6.9 2.8 1.5 5.4 1.9 8.1 1.9 5.6 0 9.1-3 9.1-7.7v-.1c0-4.4-3.9-6-7.6-7.2l-.5-.2c-2.8-.9-5.2-1.7-5.2-3.5v-.1c0-1.6 1.4-2.7 3.6-2.7 2.4 0 5.3.8 7.1 1.8 0 0 .5.3.7-.2.1-.3 1-2.8 1.1-3.1s-.1-.5-.3-.6c-2.1-1.3-5-2.1-8-2.1h-.6c-5.1 0-8.7 3.1-8.7 7.5v.1c0 4.7 3.9 6.2 7.6 7.2l.6.2c2.7.8 5 1.5 5 3.4v.1c0 1.7-1.5 3-3.9 3-.9 0-3.9 0-7.2-2.1-.4-.2-.6-.4-.9-.6-.2-.1-.6-.3-.7.3zm81.8 0c-.2.4.1.5.1.6.5.4 1 .6 1.6.9 2.8 1.5 5.4 1.9 8.1 1.9 5.6 0 9.1-3 9.1-7.7v-.1c0-4.4-3.9-6-7.6-7.2l-.5-.2c-2.8-.9-5.2-1.7-5.2-3.5v-.1c0-1.6 1.4-2.7 3.6-2.7 2.4 0 5.3.8 7.1 1.8 0 0 .5.3.7-.2.1-.3 1-2.8 1.1-3.1s-.1-.5-.3-.6c-2.1-1.3-5-2.1-8-2.1h-.6c-5.1 0-8.7 3.1-8.7 7.5v.1c0 4.7 3.9 6.2 7.6 7.2l.6.2c2.7.8 5 1.5 5 3.4v.1c0 1.7-1.5 3-3.9 3-.9 0-3.9 0-7.2-2.1-.4-.2-.6-.4-.9-.6-.1-.1-.6-.2-.7.3zm60.4-14.4c-.5-1.5-1.2-2.9-2.1-4-1-1.1-2.2-2.1-3.6-2.7-1.4-.7-3.1-1-5-1s-3.6.3-5 1-2.6 1.6-3.6 2.7c-.9 1.1-1.7 2.5-2.1 4-.5 1.5-.7 3.2-.7 5s.2 3.5.7 5 1.2 2.9 2.1 4c1 1.1 2.2 2.1 3.6 2.7s3.1 1 5 1 3.6-.3 5-1c1.4-.6 2.6-1.6 3.6-2.7.9-1.1 1.7-2.5 2.1-4 .5-1.5.7-3.2.7-5s-.2-3.5-.7-5m-4.6 5q0 4.05-1.5 6.3c-1.5 2.25-2.5 2.2-4.5 2.2-2.1 0-3.5-.7-4.5-2.2s-1.5-3.6-1.5-6.3.5-4.8 1.5-6.3 2.4-2.2 4.5-2.2 3.6.7 4.5 2.2q1.5 2.25 1.5 6.3m42.9 7.8c-.2-.5-.6-.3-.6-.3-.7.3-1.4.5-2.2.6s-1.6.2-2.6.2c-2.3 0-4-.7-5.3-2s-2-3.5-2-6.4c0-2.6.6-4.6 1.8-6.1 1.1-1.5 2.9-2.3 5.2-2.3 1.9 0 3.4.2 4.9.7 0 0 .4.2.5-.3.4-1.1.7-1.9 1.1-3.2.1-.4-.2-.5-.3-.5-.6-.2-2-.6-3.1-.8-1-.2-2.2-.2-3.5-.2-2 0-3.7.3-5.2 1s-2.8 1.6-3.8 2.7-1.8 2.5-2.3 4-.8 3.2-.8 5c0 3.9 1 7 3.1 9.3s5.2 3.5 9.2 3.5c2.4 0 4.8-.5 6.6-1.2 0 0 .3-.2.2-.6zM243.7 84c-.4-1.5-1.4-3-2-3.7-1-1.1-2-1.9-3-2.3q-1.95-.9-4.5-.9c-2 0-3.8.3-5.2 1-1.5.7-2.7 1.6-3.6 2.8-1 1.2-1.7 2.5-2.1 4.1-.5 1.6-.7 3.2-.7 5s.2 3.5.7 5 1.2 2.9 2.3 4c1 1.1 2.4 2 4 2.6s3.5.9 5.7.9c4.6 0 7-1 7.9-1.6.2-.1.3-.3.1-.8l-1-2.9c-.2-.4-.6-.3-.6-.3-1.1.4-2.7 1.2-6.5 1.2-2.4 0-4.3-.7-5.4-1.9-1.2-1.2-1.7-2.9-1.8-5.2h15.8s.4 0 .5-.4c-.1 0 .4-3-.6-6.6M228 87.3c.2-1.5.6-2.7 1.3-3.7 1-1.5 2.4-2.3 4.5-2.3s3.4.8 4.4 2.3c.7 1 .9 2.3 1 3.7zM117.4 84c-.4-1.5-1.4-3-2-3.7-1-1.1-2-1.9-3-2.3q-1.95-.9-4.5-.9c-2 0-3.8.3-5.2 1-1.5.7-2.7 1.6-3.6 2.8-1 1.2-1.7 2.5-2.1 4.1-.5 1.6-.7 3.2-.7 5s.2 3.5.7 5 1.2 2.9 2.3 4c1 1.1 2.4 2 4 2.6s3.5.9 5.7.9c4.6 0 7-1 7.9-1.6.2-.1.3-.3.1-.8l-1-2.9c-.2-.4-.6-.3-.6-.3-1.1.4-2.7 1.2-6.5 1.2-2.4 0-4.3-.7-5.4-1.9-1.2-1.2-1.7-2.9-1.8-5.2h15.8s.4 0 .5-.4c-.1 0 .4-3-.6-6.6m-15.7 3.3c.2-1.5.6-2.7 1.3-3.7 1-1.5 2.4-2.3 4.5-2.3s3.4.8 4.4 2.3c.6 1 .9 2.3 1 3.7zm-27.8-.8c-.6 0-1.5-.1-2.5-.1a16 16 0 0 0-3.9.5q-1.8.45-3.3 1.5c-1.5 1.05-1.7 1.6-2.3 2.6s-.8 2.3-.8 3.6c0 1.4.2 2.6.7 3.6s1.2 1.8 2.1 2.5c.9.6 2 1.1 3.2 1.4s2.6.4 4.2.4 3.2-.1 4.8-.4c1.5-.3 3.4-.6 4-.8.5-.1 1.1-.3 1.1-.3.4-.1.4-.5.4-.5V86.1c0-3.2-.8-5.5-2.5-7-1.7-1.4-4.1-2.2-7.2-2.2-1.2 0-3.1.2-4.2.4 0 0-3.4.7-4.9 1.8 0 0-.3.2-.1.6l1.1 3c.1.4.5.3.5.3s.1 0 .3-.1c3-1.6 6.9-1.6 6.9-1.6 1.7 0 3 .3 3.9 1s1.3 1.7 1.3 3.8v.7c-1.6-.1-2.8-.3-2.8-.3m-6.3 11.1c-.6-.5-.7-.6-.9-.9-.3-.5-.5-1.2-.5-2.1 0-1.4.5-2.4 1.4-3.1 0 0 1.4-1.2 4.6-1.1 2.3 0 4.3.4 4.3.4V98s-2 .4-4.3.6c-3.2.1-4.6-1-4.6-1"></path><path d="M201.1 78.4c.1-.4-.1-.5-.2-.6-.3-.1-1.6-.4-2.6-.4-2-.1-3.1.2-4.1.7-1 .4-2.1 1.2-2.7 2v-1.9c0-.3-.2-.5-.5-.5h-4c-.3 0-.5.2-.5.5v23.5c0 .3.2.5.5.5h4.1c.3 0 .5-.2.5-.5V89.9c0-1.6.2-3.2.5-4.1.3-1 .8-1.8 1.4-2.3.6-.6 1.2-1 1.9-1.2s1.5-.3 2.1-.3c.8 0 1.7.2 1.7.2.3 0 .5-.2.6-.4.4-.8 1.2-3 1.3-3.4m-38.9-10.9c-.5-.2-1-.3-1.6-.4s-1.3-.2-2.1-.2c-2.9 0-5.1.8-6.7 2.4s-2.6 4-3.2 7.2l-.2 1.1h-3.6s-.4 0-.5.5l-.6 3.3c0 .3.1.5.5.5h3.5l-3.5 19.7q-.45 2.4-.9 3.9c-.45 1.5-.7 1.7-1.1 2.2s-.8.9-1.4 1.1c-.5.2-1.2.3-1.9.3-.4 0-.9-.1-1.3-.1-.4-.1-.6-.2-.9-.3 0 0-.4-.2-.6.3-.1.3-1.1 2.9-1.2 3.2s0 .6.2.6c.5.2.8.3 1.4.4.9.2 1.6.2 2.3.2q2.25 0 3.9-.6c1.65-.6 2.1-1.1 2.9-2 .9-1 1.5-2.1 2-3.5s1-3.2 1.4-5.3l3.6-20.1h5.2s.4 0 .5-.5l.6-3.3c0-.3-.1-.5-.5-.5h-5c0-.1.3-1.9.8-3.6.2-.7.7-1.3 1.1-1.7s.8-.7 1.3-.8c.5-.2 1.1-.2 1.7-.2.5 0 .9.1 1.3.1.5.1.7.2.8.2.5.2.6 0 .7-.2l1.2-3.3c.3-.4 0-.5-.1-.6m-70.5 34.1c0 .3-.2.5-.5.5H87c-.3 0-.5-.2-.5-.5V68c0-.3.2-.5.5-.5h4.2c.3 0 .5.2.5.5z"></path></g></g></svg>`, 
-                'vdc_azure_backup': `<svg aria-hidden="true" class="w-6 h-6" viewBox="0 0 20 20"><defs><linearGradient id="azure_a" x1="9.06" x2="4.143" y1="-209.579" y2="-224.105" gradientTransform="matrix(1 0 0 -1 0 -206)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#114a8b"></stop><stop offset="1" stop-color="#0669bc"></stop></linearGradient><linearGradient id="azure_b" x1="10.595" x2="9.458" y1="-216.348" y2="-216.733" gradientTransform="matrix(1 0 0 -1 0 -206)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-opacity="0.3"></stop><stop offset="0.071" stop-opacity="0.2"></stop><stop offset="0.321" stop-opacity="0.1"></stop><stop offset="0.623" stop-opacity="0.05"></stop><stop offset="1" stop-opacity="0"></stop></linearGradient><linearGradient id="azure_c" x1="10.005" x2="15.403" y1="-209.142" y2="-223.522" gradientTransform="matrix(1 0 0 -1 0 -206)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#3ccbf4"></stop><stop offset="1" stop-color="#2892df"></stop></linearGradient></defs><path fill="url(#azure_a)" d="M7.334 2.462h4.734L7.153 17.024a.76.76 0 0 1-.715.514H2.753a.75.75 0 0 1-.612-.314.76.76 0 0 1-.102-.681l4.58-13.567a.75.75 0 0 1 .715-.514"></path><path fill="#0078d4" d="M14.214 12.229H6.706a.35.35 0 0 0-.324.22.35.35 0 0 0 .086.382l4.824 4.503c.14.131.325.204.517.204h4.251l-1.848-5.308Z"></path><path fill="url(#azure_b)" d="M7.334 2.462a.75.75 0 0 0-.717.523L2.045 16.53a.75.75 0 0 0 .364.923.75.75 0 0 0 .348.084h3.78a.8.8 0 0 0 .62-.527l.912-2.687 3.257 3.037a.78.78 0 0 0 .485.177h4.235l-1.858-5.308H8.773l3.314-9.767H7.335Z"></path><path fill="url(#azure_c)" d="M13.381 2.975a.75.75 0 0 0-.715-.512H7.389a.76.76 0 0 1 .715.512l4.579 13.568a.754.754 0 0 1-.714.995h5.277a.76.76 0 0 0 .612-.314.76.76 0 0 0 .102-.681z"></path></svg>`
-            };
-            return icons[serviceKey] || `<svg aria-hidden="true" class="w-6 h-6 text-gray-500" fill="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>`;
-        }
-
-        function getProviderBadgeColor(provider) {
-            if (provider === 'Azure') return 'bg-[#0078D4]';
-            if (provider === 'AWS') return 'bg-[#FF9900] text-black';
-            return 'bg-slate-600';
-        }
-
         const serviceDisplayNames = {
-            'vdc_vault': { short: 'Vault', full: 'VAULT' },
-            'vdc_m365': { short: 'M365', full: 'M365 Protection' },
-            'vdc_entra_id': { short: 'Entra', full: 'ENTRA ID Protection' },
-            'vdc_salesforce': { short: 'SF', full: 'SALESFORCE Protection' },
-            'vdc_azure_backup': { short: 'Azure', full: 'AZURE Protection' }
+            'vdc_vault':         { short: 'Vault',             full: 'Veeam Data Cloud Vault' },
+            'vdc_m365':          { short: 'M365',              full: 'Microsoft 365 Protection' },
+            'vdc_entra_id':      { short: 'Entra ID',          full: 'Microsoft Entra ID Protection' },
+            'vdc_salesforce':    { short: 'Salesforce',        full: 'Salesforce Protection' },
+            'vdc_azure_backup':  { short: 'Azure Protection',  full: 'Microsoft Azure Protection' }
+        };
+
+        const serviceIcons = {
+            'vdc_vault':        '<rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="12" cy="12" r="3.5"/><path d="M12 8.5v7"/>',
+            'vdc_m365':         '<rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6 9-6"/>',
+            'vdc_entra_id':     '<circle cx="12" cy="8" r="3.5"/><path d="M5 20c1-4 4-6 7-6s6 2 7 6"/>',
+            'vdc_salesforce':   '<path d="M7 17h10a3.5 3.5 0 0 0 .5-7 4.5 4.5 0 0 0-8.6-.6A3 3 0 0 0 7 17z"/>',
+            'vdc_azure_backup': '<path d="M12 3l8 3v6c0 5-3.5 8.5-8 9.5-4.5-1-8-4.5-8-9.5V6z"/><path d="M9 12l2 2 4-4"/>'
+        };
+
+        // Commercial disclosures — coordinate with product before changing copy (see ADR-005).
+        const vaultEditionDescriptions = {
+            'Foundation': 'Foundation edition — includes a 20% fair usage restore limit.',
+            'Advanced':   'Advanced edition — includes unlimited restores.'
         };
 
         function getServiceDisplayName(key, type = 'short') {
             const names = serviceDisplayNames[key];
             if (names) return type === 'short' ? names.short : names.full;
             return key.replace('vdc_', '').replace('_', ' ').toUpperCase();
+        }
+
+        function buildServiceIconSvg(serviceId) {
+            const fallback = '<path d="M5 12l5 5L20 7"/>';
+            const inner = serviceIcons[serviceId] || fallback;
+            return `<svg class="svc-icon" data-service="${serviceId}" aria-hidden="true" focusable="false" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${inner}</svg>`;
         }
 
         function hideLoading() {
@@ -951,6 +1122,11 @@
             if (errorEl) errorEl.classList.add('visible');
         }
 
+        const markerLogos = {
+            azure: (uid) => `<svg aria-hidden="true" focusable="false" viewBox="0 0 20 20"><defs><linearGradient id="azure_a_${uid}" x1="9.06" x2="4.143" y1="-209.579" y2="-224.105" gradientTransform="matrix(1 0 0 -1 0 -206)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#114a8b"></stop><stop offset="1" stop-color="#0669bc"></stop></linearGradient><linearGradient id="azure_b_${uid}" x1="10.595" x2="9.458" y1="-216.348" y2="-216.733" gradientTransform="matrix(1 0 0 -1 0 -206)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-opacity="0.3"></stop><stop offset="0.071" stop-opacity="0.2"></stop><stop offset="0.321" stop-opacity="0.1"></stop><stop offset="0.623" stop-opacity="0.05"></stop><stop offset="1" stop-opacity="0"></stop></linearGradient><linearGradient id="azure_c_${uid}" x1="10.005" x2="15.403" y1="-209.142" y2="-223.522" gradientTransform="matrix(1 0 0 -1 0 -206)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#3ccbf4"></stop><stop offset="1" stop-color="#2892df"></stop></linearGradient></defs><path fill="url(#azure_a_${uid})" d="M7.334 2.462h4.734L7.153 17.024a.76.76 0 0 1-.715.514H2.753a.75.75 0 0 1-.612-.314.76.76 0 0 1-.102-.681l4.58-13.567a.75.75 0 0 1 .715-.514"></path><path fill="#0078d4" d="M14.214 12.229H6.706a.35.35 0 0 0-.324.22.35.35 0 0 0 .086.382l4.824 4.503c.14.131.325.204.517.204h4.251l-1.848-5.308Z"></path><path fill="url(#azure_b_${uid})" d="M7.334 2.462a.75.75 0 0 0-.717.523L2.045 16.53a.75.75 0 0 0 .364.923.75.75 0 0 0 .348.084h3.78a.8.8 0 0 0 .62-.527l.912-2.687 3.257 3.037a.78.78 0 0 0 .485.177h4.235l-1.858-5.308H8.773l3.314-9.767H7.335Z"></path><path fill="url(#azure_c_${uid})" d="M13.381 2.975a.75.75 0 0 0-.715-.512H7.389a.76.76 0 0 1 .715.512l4.579 13.568a.754.754 0 0 1-.714.995h5.277a.76.76 0 0 0 .612-.314.76.76 0 0 0 .102-.681z"></path></svg>`,
+            aws: () => `<svg aria-hidden="true" focusable="false" viewBox="0 0 640 640" fill="#FF9900"><path d="M180.4 267C179.7 289.6 191 299.7 191.3 306C191.2 307.3 190.7 308.5 190 309.6C189.3 310.7 188.3 311.6 187.2 312.2L174.4 321.2C172.7 322.4 170.8 323 168.8 323.1C168.4 323.1 160.6 324.9 148.3 297.5C140.8 306.9 131.3 314.4 120.4 319.5C109.5 324.6 97.7 327.2 85.7 327C69.4 327.9 25.3 317.8 27.6 270.8C26 232.5 61.7 208.7 98.5 210.8C105.6 210.8 120.1 211.2 145.5 217.1L145.5 201.5C148.2 175 130.8 154.5 100.7 157.6C98.3 157.6 81.3 157.1 54.9 167.7C47.5 171.1 46.6 170.5 44.1 170.5C36.7 170.5 39.7 149 41.2 146.3C46.4 139.9 77.1 127.9 107.1 128.1C127.2 126.3 147.2 132.5 162.8 145.4C169.1 152.5 174 160.8 177 169.8C180 178.8 181.2 188.3 180.5 197.8L180.5 267.1zM94 299.4C126.4 298.9 140.2 279.4 143.3 268.9C145.8 258.8 145.4 252.5 145.4 241.5C135.7 239.2 121.8 236.6 105.8 236.6C90.6 235.5 63 242.2 64.1 268.9C62.9 285.7 75.2 300.3 94.1 299.4zM264.9 322.5C257 323.2 253.4 317.6 252.2 312.1L202.4 147.4C201.4 144.6 200.8 141.8 200.5 138.8C200.3 137.6 200.6 136.4 201.3 135.4C202 134.4 203.1 133.8 204.3 133.6C204.5 133.6 202.2 133.6 226.5 133.6C235.3 132.7 238.1 139.6 239.1 144L274.9 284.8L308.1 144C308.6 140.8 311 132.9 320.9 133.8L338.1 133.8C340.3 133.6 349.2 133.3 350.8 144.2L384.1 286.7L421 144.1C421.5 141.9 423.7 132.7 433.7 133.7L453.4 133.7C454.3 133.6 459.6 132.9 458.7 142.3C458.3 144.1 462.1 131.6 405.9 312.2C404.8 317.7 401.1 323.3 393.2 322.6L374.5 322.6C363.6 323.8 362 312.9 361.8 311.9L328.6 174.8L295.8 311.8C295.6 312.9 294.1 323.7 283.1 322.5L264.8 322.5L264.8 322.5zM538.4 328.1C532.5 328.1 504.5 327.8 481 315.8C478.7 314.8 476.7 313.2 475.3 311C473.9 308.8 473.2 306.4 473.2 303.9L473.2 293.2C473.2 284.7 479.4 286.3 482 287.3C492 291.4 498.5 294.4 510.8 296.9C547.5 304.4 563.6 294.6 567.5 292.4C580.7 284.6 581.7 266.7 572.8 257.5C562.3 248.7 557.3 248.4 519.7 236.5C515.1 235.2 476 222.9 475.9 184.1C475.3 155.9 500.9 127.9 545.4 128.1C558.1 128.1 591.8 132.2 601 143.7C602.4 145.8 603 148.3 602.9 150.7L602.9 160.8C602.9 165.2 601.3 167.5 598 167.5C590.3 166.6 576.6 156.3 548.8 156.7C541.9 156.3 508.9 157.6 510.4 181.7C510 200.7 537 207.8 540.1 208.6C576.6 219.6 588.7 221.4 603.2 238.2C620.3 260.4 611.1 286.5 607.5 293.6C588.4 331.1 539.1 328 538.2 328zM578.6 433C508.6 484.7 406.9 512.2 320.1 512.2C203 513 89.8 469.9 2.8 391.5C-3.7 385.6 2 377.5 10 382C106.5 437.2 215.7 466.2 326.9 466.1C409.9 465.7 492 448.8 568.5 416.6C580.3 411.6 590.3 424.4 578.6 433zM607.8 399.7C598.8 388.2 548.5 394.3 526 397C519.2 397.8 518.1 391.9 524.2 387.5C564.3 359.3 630.1 367.4 637.6 376.9C645.1 386.4 635.5 452.3 598 483.8C592.2 488.7 586.7 486.1 589.3 479.7C597.7 458.4 616.7 411.2 607.7 399.7z"/></svg>`
+        };
+
         let map;
         const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         try {
@@ -959,18 +1135,17 @@
             }
 
             map = L.map('map', {
-                center: [-25, 140],
-                minZoom: 3.0,
+                minZoom: 2,
                 maxZoom: 6.0,
-                zoom: 3,
                 zoomControl: false,
                 worldCopyJump: true,
                 maxBoundsViscosity: 1.0,
-                maxBounds: [[-60, -185], [90, 185]],
+                maxBounds: [[-60, -185], [90, 210]],
                 fadeAnimation: !reducedMotion,
                 zoomAnimation: !reducedMotion,
                 markerZoomAnimation: !reducedMotion
             });
+            window.__map = map;
         } catch (e) {
             console.error('Map initialization failed:', e);
             showError();
@@ -981,19 +1156,11 @@
 
         const legend = L.control({ position: 'bottomleft' });
         legend.onAdd = function() {
-            const div = L.DomUtil.create('div', 'leaflet-bar legend-container');
+            const div = L.DomUtil.create('div', 'leaflet-bar panel-legend');
             div.innerHTML = `
-                <div class="bg-slate-800/95 light:bg-white/95 backdrop-blur-sm border border-slate-600/50 light:border-slate-200 rounded-xl px-4 py-3 text-xs shadow-lg">
-                    <div class="font-semibold text-slate-400 light:text-slate-500 mb-2.5 uppercase tracking-wider text-[10px]">Providers</div>
-                    <div class="flex items-center gap-2.5 mb-2">
-                        <span class="w-3.5 h-3.5 rounded-full bg-[#0078D4] border-2 border-white/30 shadow-sm shadow-blue-500/30"></span>
-                        <span class="text-white light:text-slate-900 font-medium">Azure</span>
-                    </div>
-                    <div class="flex items-center gap-2.5">
-                        <span class="w-3.5 h-3.5 rounded-full bg-[#FF9900] border-2 border-white/30 shadow-sm shadow-orange-500/30"></span>
-                        <span class="text-white light:text-slate-900 font-medium">AWS</span>
-                    </div>
-                </div>
+                <div class="label">Providers</div>
+                <div class="row"><span class="glyph">${markerLogos.azure('legend')}</span><span>Azure</span><span class="count" id="legendAzureCount"></span></div>
+                <div class="row"><span class="glyph">${markerLogos.aws('legend')}</span><span>AWS</span><span class="count" id="legendAwsCount"></span></div>
             `;
             return div;
         };
@@ -1003,7 +1170,7 @@
             attribution: '&copy; OpenStreetMap &copy; CARTO',
             maxZoom: 19
         });
-        
+
         const lightTiles = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
             attribution: '&copy; OpenStreetMap &copy; CARTO',
             maxZoom: 19
@@ -1011,6 +1178,15 @@
 
         let currentTiles = darkTiles;
         currentTiles.addTo(map);
+
+        const regionLatLngs = regions
+            .filter(r => Array.isArray(r.coords) && r.coords.length === 2)
+            .map(r => r.coords);
+        map.fitBounds(L.latLngBounds(regionLatLngs), {
+            padding: [48, 48],
+            maxZoom: 3,
+            animate: false
+        });
 
         const systemDarkQuery = window.matchMedia('(prefers-color-scheme: dark)');
         const themeModes = ['system', 'dark', 'light'];
@@ -1033,7 +1209,7 @@
                 html.classList.add('light');
                 html.classList.remove('dark');
                 html.style.colorScheme = 'light';
-                if (themeMeta) themeMeta.setAttribute('content', '#f1f5f9');
+                if (themeMeta) themeMeta.setAttribute('content', '#fafbfc');
                 if (map.hasLayer(darkTiles)) map.removeLayer(darkTiles);
                 if (!map.hasLayer(lightTiles)) lightTiles.addTo(map);
                 currentTiles = lightTiles;
@@ -1041,7 +1217,7 @@
                 html.classList.remove('light');
                 html.classList.add('dark');
                 html.style.colorScheme = 'dark';
-                if (themeMeta) themeMeta.setAttribute('content', '#0f172a');
+                if (themeMeta) themeMeta.setAttribute('content', '#0a0d12');
                 if (map.hasLayer(lightTiles)) map.removeLayer(lightTiles);
                 if (!map.hasLayer(darkTiles)) darkTiles.addTo(map);
                 currentTiles = darkTiles;
@@ -1086,39 +1262,15 @@
             LARGE: 20
         };
 
-        const PROVIDER_BAR = {
-            MIN_WIDTH: 4,
-            MAX_WIDTH: 24
-        };
-
         function createClusterIcon(cluster) {
             const count = cluster.getChildCount();
-            const markers = cluster.getAllChildMarkers();
-            
-            let azureCount = 0;
-            let awsCount = 0;
-            markers.forEach(m => {
-                if (m.options.provider === 'Azure') azureCount++;
-                else if (m.options.provider === 'AWS') awsCount++;
-            });
-            
+
             let sizeClass = 'cluster-small';
             if (count > CLUSTER_SIZE_THRESHOLDS.LARGE) sizeClass = 'cluster-large';
             else if (count > CLUSTER_SIZE_THRESHOLDS.MEDIUM) sizeClass = 'cluster-medium';
-            
-            // Minimum 4px width prevents bars from being invisible at high zoom levels or with uneven provider distributions
-            const total = azureCount + awsCount;
-            const azureWidth = azureCount > 0 ? Math.max(PROVIDER_BAR.MIN_WIDTH, Math.round((azureCount / total) * PROVIDER_BAR.MAX_WIDTH)) : 0;
-            const awsWidth = awsCount > 0 ? Math.max(PROVIDER_BAR.MIN_WIDTH, Math.round((awsCount / total) * PROVIDER_BAR.MAX_WIDTH)) : 0;
-            
+
             return L.divIcon({
-                html: `<div class="cluster-marker ${sizeClass}">
-                    <span>${count}</span>
-                    <div class="cluster-providers">
-                        ${azureCount > 0 ? `<div class="azure-bar" style="width: ${azureWidth}px"></div>` : ''}
-                        ${awsCount > 0 ? `<div class="aws-bar" style="width: ${awsWidth}px"></div>` : ''}
-                    </div>
-                </div>`,
+                html: `<div class="cluster-marker ${sizeClass}"><span>${count}</span></div>`,
                 className: 'custom-cluster-marker',
                 iconSize: L.point(52, 52),
                 iconAnchor: L.point(26, 26)
@@ -1234,6 +1386,8 @@
         function renderMap() {
             clusterGroup.clearLayers();
             let visibleCount = 0;
+            let visibleAzureCount = 0;
+            let visibleAwsCount = 0;
 
             const pFilter = providerFilter.value;
             const selectedServices = getSelectedServices();
@@ -1254,120 +1408,114 @@
 
                 if (matchesProvider && matchesService) {
                     
-                    let iconGrid = '';
-                    let serviceList = '';
-                    const providerColor = getProviderBadgeColor(region.provider);
+                    const providerKey = region.provider.toLowerCase();
+                    const providerGlyph = providerKey === 'azure'
+                        ? '<svg aria-hidden="true" focusable="false" viewBox="0 0 20 20" fill="currentColor"><path d="M7.3 2.5h4.7L7.2 17a.8.8 0 01-.7.5H2.8a.7.7 0 01-.7-1l4.5-13.5a.8.8 0 01.7-.5z"/></svg>'
+                        : '<svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" fill="currentColor"><path d="M13.5 5.3v3.7l3.5 2-3.5 2v3.7l6.7-4.2V9.6L13.5 5.3zM10.5 5.3L3.8 9.6v3.9l6.7 4.2v-3.7l-3.5-2 3.5-2V5.3z"/></svg>';
+
+                    let serviceRows = '';
+                    let svcCount = 0;
 
                     if (region.services) {
                         Object.keys(region.services).forEach(key => {
                             const serviceValue = region.services[key];
-                            
-                            iconGrid += `
-                                <div class="service-icon-wrapper flex flex-col items-center justify-center w-12 p-1.5 rounded-lg hover:bg-slate-700/30 cursor-default">
-                                    ${getServiceIcon(key)}
-                                    <span class="text-[9px] mt-1.5 text-slate-400 font-medium uppercase tracking-wide">${getServiceDisplayName(key, 'short')}</span>
-                                </div>
-                            `;
+                            svcCount += 1;
+                            const displayName = getServiceDisplayName(key, 'full');
+
+                            const iconSvg = buildServiceIconSvg(key);
 
                             if (serviceValue === true) {
-                                serviceList += `
-                                    <li class="flex items-center text-xs py-1.5 border-b border-slate-700/50 last:border-0">
-                                        <span class="text-slate-300 flex-1 font-medium">
-                                            ${getServiceDisplayName(key, 'full')} 
-                                        </span>
-                                        <span class="text-green-400 ml-2 text-[10px] bg-green-500/10 px-2 py-0.5 rounded-full border border-green-500/30 font-medium">
-                                            Available
-                                        </span>
-                                    </li>
+                                serviceRows += `
+                                    <div class="popup-svc">
+                                        ${iconSvg}
+                                        <span class="name">${displayName}</span>
+                                        <span class="available">Available</span>
+                                    </div>
                                 `;
                             } else {
                                 const configs = ensureArray(serviceValue);
-                                configs.forEach(conf => {
-                                    if (!conf) return; 
-
-                                    const badgeClass = conf.tier === 'Core' 
-                                        ? 'text-blue-400 bg-blue-500/10 border-blue-500/30' 
-                                        : 'text-amber-400 bg-amber-500/10 border-amber-500/30';
-                                    
-                                    serviceList += `
-                                        <li class="flex items-center text-xs py-1.5 border-b border-slate-700/50 last:border-0">
-                                            <span class="text-slate-300 font-medium flex-1">
-                                                ${getServiceDisplayName(key, 'full')} 
-                                            </span>
-                                            <span class="${badgeClass} ml-2 text-[10px] px-2 py-0.5 rounded-full border font-medium">
-                                                ${conf.edition || 'Std'} (${conf.tier || 'N/A'})
-                                            </span>
-                                        </li>
-                                    `;
-                                });
+                                const pills = configs
+                                    .filter(c => c)
+                                    .map(c => {
+                                        const cls = c.tier === 'Core' ? 'pill core' : 'pill noncore';
+                                        const edition = c.edition || 'Std';
+                                        const tier = c.tier || 'N/A';
+                                        const pillText = `${edition} · ${tier}`;
+                                        const desc = vaultEditionDescriptions[edition];
+                                        if (!desc) return `<span class="${cls}">${pillText}</span>`;
+                                        const tipAttr = desc.replace(/"/g, '&quot;');
+                                        const ariaAttr = `${pillText}. ${desc}`.replace(/"/g, '&quot;');
+                                        return `<span class="${cls}" data-tooltip="${tipAttr}" aria-label="${ariaAttr}" tabindex="0">${pillText}</span>`;
+                                    })
+                                    .join('');
+                                serviceRows += `
+                                    <div class="popup-svc">
+                                        ${iconSvg}
+                                        <span class="name">${displayName}</span>
+                                        <span class="pills">${pills}</span>
+                                    </div>
+                                `;
                             }
                         });
                     }
 
+                    const safeCoord = Array.isArray(region.coords)
+                        ? `${Math.abs(region.coords[0]).toFixed(3)}°${region.coords[0] >= 0 ? 'N' : 'S'} · ${Math.abs(region.coords[1]).toFixed(3)}°${region.coords[1] >= 0 ? 'E' : 'W'}`
+                        : '';
+                    const regionIdSlug = (region.id || region.name).toLowerCase().replace(/_/g, '-');
+
                     const popupHTML = `
-                        <div class="w-[calc(100vw-60px)] sm:w-80 max-w-80 p-3 sm:p-5 font-sans">
-                            <div class="flex justify-between items-start mb-3 sm:mb-4">
-                                <h3 class="font-bold text-base sm:text-lg text-white leading-tight pr-2 sm:pr-3">${region.name}</h3>
-                                <span class="${providerColor} text-white text-[9px] sm:text-[10px] font-bold px-2 sm:px-2.5 py-0.5 sm:py-1 rounded-md shadow-md flex-shrink-0">
-                                    ${region.provider.toUpperCase()}
-                                </span>
+                        <div class="popup-card">
+                            <div class="popup-head">
+                                <div class="popup-region-id">Region // ${regionIdSlug}</div>
+                                <div class="popup-region-name">${region.name}</div>
+                                <div class="popup-region-coord">${safeCoord}</div>
                             </div>
-
-                            <div class="flex gap-1 mb-3 sm:mb-4 p-2 sm:p-2.5 bg-slate-900/60 rounded-xl border border-slate-700/30 overflow-x-auto -mx-1 px-1" style="scrollbar-width: thin;">
-                                ${iconGrid}
+                            <div class="popup-provider-strip">
+                                <span class="pchip ${providerKey}">${providerGlyph} ${region.provider}</span>
+                                <span style="color:var(--text-dim)">·</span>
+                                <span>${String(svcCount).padStart(2, '0')} / ${String(Object.keys(serviceDisplayNames).length).padStart(2, '0')} Services</span>
                             </div>
-
-                            <div class="bg-slate-800/80 rounded-xl border border-slate-700/50 overflow-hidden shadow-inner">
-                                <div class="bg-gradient-to-r from-slate-700/60 to-slate-700/30 px-3 sm:px-3.5 py-1.5 sm:py-2 border-b border-slate-700/50">
-                                    <span class="text-[9px] sm:text-[10px] font-semibold text-slate-400 tracking-wider uppercase">Available Services</span>
-                                </div>
-                                <ul class="px-3 sm:px-3.5 py-2 sm:py-2.5 space-y-0">
-                                    ${serviceList}
-                                </ul>
-                            </div>
+                            <div class="popup-services">${serviceRows}</div>
                         </div>
                     `;
 
-                    const marker = L.circleMarker(region.coords, {
-                        radius: 9,
-                        fillColor: region.provider === 'Azure' ? '#0078D4' : '#FF9900',
-                        color: region.provider === 'Azure' ? '#60a5fa' : '#fcd34d',
-                        weight: 2,
-                        opacity: 0.8,
-                        fillOpacity: 0.9,
+                    const markerIcon = L.divIcon({
+                        className: '',
+                        html: `<div class="map-marker-dot provider-${providerKey}">${markerLogos[providerKey](region.id)}</div>`,
+                        iconSize: [28, 28],
+                        iconAnchor: [14, 14],
+                        popupAnchor: [0, -14]
+                    });
+                    const marker = L.marker(region.coords, {
+                        icon: markerIcon,
+                        keyboard: true,
+                        alt: `${region.provider} region: ${region.name}`,
                         provider: region.provider
                     }).bindPopup(popupHTML);
 
-                    marker.on('mouseover', function() {
-                        this.setStyle({ radius: 12, weight: 3, opacity: 1 });
-                    });
-                    marker.on('mouseout', function() {
-                        this.setStyle({ radius: 9, weight: 2, opacity: 0.8 });
-                    });
-
                     clusterGroup.addLayer(marker);
                     visibleCount++;
+                    if (region.provider === 'Azure') visibleAzureCount++;
+                    else if (region.provider === 'AWS') visibleAwsCount++;
                 }
             });
 
-            updateRegionCount(visibleCount, regions.length);
+            updateRegionCount(visibleCount, regions.length, visibleAzureCount, visibleAwsCount);
             updateResetButtonVisibility();
         }
 
         providerFilter.addEventListener('change', () => handleFilterChange('push'));
 
-        function updateRegionCount(visible, total) {
+        function updateRegionCount(visible, total, azureVisible, awsVisible) {
             document.getElementById('visibleCount').textContent = visible;
             document.getElementById('totalCount').textContent = total;
-            
-            const countEl = document.getElementById('visibleCount');
-            if (visible < total) {
-                countEl.classList.add('text-amber-400');
-                countEl.classList.remove('text-white', 'light:text-slate-900');
-            } else {
-                countEl.classList.remove('text-amber-400');
-                countEl.classList.add('text-white', 'light:text-slate-900');
-            }
+            // Legend reflects the currently-visible markers, not the
+            // full dataset — keeps the "Live" label honest under filters.
+            const azureEl = document.getElementById('legendAzureCount');
+            const awsEl = document.getElementById('legendAwsCount');
+            if (azureEl) azureEl.textContent = azureVisible;
+            if (awsEl) awsEl.textContent = awsVisible;
         }
 
         function hasActiveFilters() {
@@ -1399,6 +1547,19 @@
         });
 
         updateRegionCount(0, regions.length);
+        // HUD provider/service counts mirror the dataset, so the strip stays honest
+        // when a new provider or service is added (see code-review item #1, PR #103).
+        const hudProviderCountEl = document.getElementById('hudProviderCount');
+        const hudServiceCountEl = document.getElementById('hudServiceCount');
+        if (hudProviderCountEl) {
+            const providerCount = new Set(regions.map(r => r.provider).filter(Boolean)).size;
+            hudProviderCountEl.textContent = String(providerCount).padStart(2, '0');
+        }
+        if (hudServiceCountEl) {
+            const serviceCount = Object.keys(serviceDisplayNames).length;
+            hudServiceCountEl.textContent = String(serviceCount).padStart(2, '0');
+        }
+
         applyFilterStateFromUrl();
         syncFilterStateToUrl('replace');
         renderMap();
@@ -1503,9 +1664,22 @@
                     if (Math.abs(markerLat - region.coords[0]) < EPSILON &&
                         Math.abs(markerLng - region.coords[1]) < EPSILON) {
                         found = true;
-                        const targetZoom = Math.max(map.getZoom(), CLUSTER_CONFIG.DISABLE_AT_ZOOM);
-                        map.setView(region.coords, targetZoom, { animate: !reducedMotion });
-                        map.once('moveend', () => marker.openPopup());
+                        // zoomToShowLayer expands the parent cluster (if any) and waits until
+                        // the marker is on the map pane before invoking the callback, so the
+                        // popup actually attaches to a live marker rather than a clustered one.
+                        // POPUP_MIN_ZOOM: below this level, the centered popup card can't
+                        // geometrically fit on a mobile viewport for edge regions like NZ,
+                        // regardless of how far maxBounds extends — the marker is forced
+                        // off-center. Escalate to zoom 4 so the popup always fits.
+                        const POPUP_MIN_ZOOM = 4;
+                        clusterGroup.zoomToShowLayer(marker, () => {
+                            if (map.getZoom() < POPUP_MIN_ZOOM) {
+                                map.once('moveend', () => marker.openPopup());
+                                map.setView(marker.getLatLng(), POPUP_MIN_ZOOM, { animate: !reducedMotion });
+                            } else {
+                                marker.openPopup();
+                            }
+                        });
                     }
                 });
             }
@@ -1578,6 +1752,15 @@
             } else if (e.key === 'Escape') {
                 setSearchDropdownOpen(false);
                 searchInput.blur();
+            }
+        });
+
+        // Prevent the search input from losing focus when a dropdown option is clicked.
+        // Keeps focus state stable across mousedown/mouseup so any future focus-driven
+        // layout shift can't move the dropdown's hit-box mid-click.
+        searchResults.addEventListener('mousedown', (e) => {
+            if (e.target.closest('.search-result-item')) {
+                e.preventDefault();
             }
         });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veeam-data-cloud-services-map",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Interactive map and API for Veeam Data Cloud service availability across AWS and Azure regions",
   "private": true,
   "scripts": {

--- a/plans/mission-control-redesign/plan.md
+++ b/plans/mission-control-redesign/plan.md
@@ -1,0 +1,1607 @@
+# Mission Control Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current generic-SaaS look with a paired dark/light "Mission Control / Workstation" aesthetic across `layouts/index.html`, so the toggle reads as one product wearing two coats: dark-on-near-black with a fluorescent accent, or light-on-cool-off-white with a muted accent. Same fonts, same layout, same posture — only the surface changes.
+
+**Architecture:** All changes land in a single file (`layouts/index.html` — the SPA). Three concurrent strands of change:
+
+1. **Visual layer** — Google Fonts (Space Grotesk + JetBrains Mono), new CSS design tokens for both themes, restyled header / controls / map panels / popup.
+2. **HTML restructure** — header becomes brand + live-data status strip + controls; popup uses one row per service with edition pills aligned right (eliminates the existing Vault row duplication).
+3. **JS updates** — circle markers become provider-shaped SVG glyphs via `L.divIcon`; service display names rename; initial map center moves from Australia to globally-balanced.
+
+The existing theme toggle stays — it still swaps `html.dark` ↔ `html.light`. Only the CSS underneath each class changes.
+
+**Tech Stack:** Existing — Hugo + Tailwind CDN + Leaflet + custom CSS in a `<style type="text/tailwindcss">` block. Adding: Google Fonts (Space Grotesk, JetBrains Mono) via `<link>`.
+
+---
+
+## File Structure
+
+| File | Action | Why |
+|---|---|---|
+| `layouts/index.html` | Modify | The whole SPA lives here; redesign touches `<head>`, the `<style>` block, the `<header>` HTML, the popup template JS, marker creation JS, and config constants. |
+| `tests/ui.spec.ts` | Modify | The marker selector `path.leaflet-interactive` breaks when circle markers become divIcon glyphs. The "Azure" service-filter checkbox is renamed to "Azure Protection". |
+| `plans/ui-styling-improvements/` | Delete | Superseded by this plan (the redesign replaces its scope wholesale). |
+| `static/llms.txt`, `static/llms-full.txt` | Untouched | API surface and endpoint behaviour are unchanged. |
+| `data/regions/**/*.yaml` | Untouched | Data shape is unchanged. |
+
+The redesign is intentionally CSS-and-template-only — no API, schema, or data-format changes.
+
+---
+
+## Tasks
+
+### Task 1: Archive the superseded plan
+
+**Files:**
+- Delete: `plans/ui-styling-improvements/plan.md`
+- Delete: `plans/ui-styling-improvements/implementation.md`
+- Delete: `plans/ui-styling-improvements/` (the now-empty directory)
+
+Note: the old plan was never committed to git (it's an untracked working-tree directory). Removal is a filesystem `rm`, not a `git rm`.
+
+- [ ] **Step 1: Verify the directory contents and confirm it is untracked**
+
+Run:
+```bash
+ls -la plans/ui-styling-improvements/
+git ls-files plans/ui-styling-improvements/
+```
+
+Expected: `ls` shows `plan.md` and `implementation.md`. `git ls-files` returns nothing (confirming the directory is untracked). If `git ls-files` returns any files, stop — fall back to `git rm -r plans/ui-styling-improvements/ && git commit -m "chore: supersede ui-styling-improvements plan"`.
+
+- [ ] **Step 2: Remove the directory**
+
+```bash
+rm -rf plans/ui-styling-improvements/
+```
+
+Expected: no output. The directory is gone.
+
+- [ ] **Step 3: Verify the removal**
+
+```bash
+ls plans/
+```
+
+Expected: only `mission-control-redesign/` remains under `plans/`.
+
+No commit is required for this task — removing untracked files leaves no diff to record. Proceed directly to Task 2.
+
+---
+
+### Task 2: Add typography and theme design tokens
+
+**Files:**
+- Modify: `layouts/index.html` — add Google Fonts to `<head>` (after the existing `<link rel="preconnect">` lines, around line 14); replace the `:root` / `body` block at the top of `<style type="text/tailwindcss">` (around lines 22–34).
+
+- [ ] **Step 1: Add Google Fonts preconnect + stylesheet link**
+
+In `layouts/index.html`, find the existing preconnect block (after the Tailwind script, before the Leaflet stylesheet). Add three new `<link>` elements directly after the existing `<link rel="preconnect" href="https://static.cloudflareinsights.com" crossorigin>` line:
+
+```html
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=JetBrains+Mono:wght@400;500;700&display=swap">
+```
+
+- [ ] **Step 2: Add design tokens at the top of the `<style>` block**
+
+Find the line `@custom-variant dark (&:where(.dark, .dark *));` (around line 23) and immediately after the two `@custom-variant` lines, insert this block (before the existing `body { … }` rule):
+
+```css
+        :root {
+            /* Dark tokens (default) */
+            --bg: #0a0d12;
+            --bg-elev: #11151c;
+            --bg-elev-2: #161b24;
+            --border: #232a35;
+            --border-strong: #2f3744;
+            --text: #e6edf3;
+            --text-mute: #8892a0;
+            --text-dim: #5a6473;
+            --accent: #00ff88;
+            --accent-soft: rgba(0, 255, 136, 0.10);
+            --accent-glow: rgba(0, 255, 136, 0.35);
+            --azure: #4ea3ff;
+            --aws: #ff9d3d;
+        }
+        html.light {
+            --bg: #fafbfc;
+            --bg-elev: #ffffff;
+            --bg-elev-2: #f4f6f8;
+            --border: #e5e8ec;
+            --border-strong: #d0d5da;
+            --text: #1a202c;
+            --text-mute: #5a6473;
+            --text-dim: #98a0ad;
+            --accent: #00805a;
+            --accent-soft: rgba(0, 128, 90, 0.10);
+            --accent-glow: rgba(0, 128, 90, 0.20);
+            --azure: #2c5fa8;
+            --aws: #d97506;
+        }
+```
+
+- [ ] **Step 3: Replace the existing `body` rule and theme-class rules**
+
+Find the existing `body { background-color: #0f172a; … }` rule and the `.dark body`, `.light body` rules immediately following (lines ~26–33). Replace those three rules with:
+
+```css
+        body {
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'JetBrains Mono', ui-monospace, monospace;
+            font-size: 13px;
+            letter-spacing: 0.005em;
+            transition: background-color 0.3s ease, color 0.3s ease;
+            touch-action: manipulation;
+        }
+```
+
+- [ ] **Step 4: Update `<meta name="theme-color">` so the address bar follows the theme**
+
+Find `<meta name="theme-color" content="#0f172a" id="themeColorMeta">` (around line 7). Change `content` to `#0a0d12` so it matches the new dark background:
+
+```html
+    <meta name="theme-color" content="#0a0d12" id="themeColorMeta">
+```
+
+Also find the JS that updates this meta tag on theme toggle (search the file for `themeColorMeta`). Update the two hex values inside it from `#0f172a` and `#f1f5f9` to `#0a0d12` (dark) and `#fafbfc` (light):
+
+```js
+// Find the existing code that does:
+//   themeColorMeta.setAttribute('content', isDark ? '#0f172a' : '#f1f5f9');
+// Change to:
+themeColorMeta.setAttribute('content', isDark ? '#0a0d12' : '#fafbfc');
+```
+
+- [ ] **Step 5: Run typecheck + start dev server to verify nothing broke**
+
+```bash
+npm run typecheck
+npm run build
+npm run dev &
+sleep 4
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8788/
+```
+
+Expected: typecheck passes, build succeeds, server returns `200`.
+
+- [ ] **Step 6: Visual sanity check**
+
+Open `http://localhost:8788/` in a browser. Body font should now be JetBrains Mono (monospace). The page may look mid-redesign — that's fine. Confirm: no console errors, no missing-font flashes that don't resolve.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add layouts/index.html
+git commit -m "feat(ui): add typography and theme design tokens"
+```
+
+---
+
+### Task 3: Rebuild the header (brand mark + status strip + controls)
+
+**Files:**
+- Modify: `layouts/index.html`
+  - HTML: replace the entire `<header>` element (around lines 583–684).
+  - CSS: append new header rules near the existing `.header-gradient` rules (around line 77) — keep the existing rules for now, the new ones override them by class specificity.
+
+- [ ] **Step 1: Append the new header CSS**
+
+In the `<style>` block, after the existing `.header-gradient { … }` rules (around line 82), insert:
+
+```css
+        /* === NEW HEADER === */
+        .hud {
+            display: flex;
+            align-items: center;
+            padding: 14px 24px;
+            background: var(--bg-elev);
+            border-bottom: 1px solid var(--border);
+            padding-top: calc(14px + env(safe-area-inset-top));
+        }
+        .brand { display: flex; align-items: center; gap: 14px; }
+        .brand-mark {
+            width: 26px; height: 26px;
+            position: relative;
+            display: flex; align-items: center; justify-content: center;
+            flex-shrink: 0;
+        }
+        .brand-mark::after {
+            content: ''; width: 10px; height: 10px;
+            background: var(--accent); border-radius: 50%;
+            box-shadow: 0 0 14px var(--accent-glow);
+        }
+        .brand-mark::before {
+            content: ''; position: absolute; inset: 4px;
+            border: 1.5px solid var(--accent);
+            border-radius: 50%;
+            opacity: 0.35;
+            animation: brand-pulse 2.4s ease-out infinite;
+        }
+        @keyframes brand-pulse {
+            0% { transform: scale(0.7); opacity: 0.6; }
+            100% { transform: scale(1.6); opacity: 0; }
+        }
+        .brand-text { display: flex; flex-direction: column; gap: 1px; }
+        .brand-text .tag {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 9px; letter-spacing: 0.18em;
+            color: var(--text-dim);
+            text-transform: uppercase;
+        }
+        .brand-text .title {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 700; font-size: 15px;
+            letter-spacing: -0.005em;
+            color: var(--text);
+        }
+        .brand-text .title em { color: var(--accent); font-style: normal; }
+
+        .status {
+            margin-left: 36px;
+            display: flex; align-items: center; gap: 24px;
+            flex: 1;
+            font-size: 11px; color: var(--text-mute);
+            text-transform: uppercase; letter-spacing: 0.12em;
+        }
+        .status .row { display: flex; align-items: baseline; gap: 8px; }
+        .status .row b {
+            font-weight: 500; color: var(--text);
+            font-size: 13px; letter-spacing: 0;
+        }
+        .status .sep { width: 1px; height: 14px; background: var(--border); }
+        .status .dot {
+            width: 6px; height: 6px;
+            background: var(--accent); border-radius: 50%;
+            box-shadow: 0 0 6px var(--accent-glow);
+        }
+
+        .hud .controls { display: flex; align-items: center; gap: 6px; }
+
+        @media (max-width: 900px) {
+            .status { display: none; }
+        }
+        @media (max-width: 640px) {
+            .hud { padding: 10px 14px; gap: 8px; flex-wrap: wrap; }
+            .brand-text .tag { display: none; }
+            .hud .controls { margin-left: auto; }
+        }
+```
+
+- [ ] **Step 2: Replace the header markup**
+
+Find the existing `<header class="header-gradient …">` element (starts around line 583) and ends with its closing `</header>` (around line 684). Replace the entire block with:
+
+```html
+    <header class="hud">
+        <div class="brand">
+            <div class="brand-mark" aria-hidden="true"></div>
+            <div class="brand-text">
+                <span class="tag">VDC // Global Telemetry</span>
+                <h1 class="title"><em>Veeam</em> Data Cloud Service Map</h1>
+            </div>
+        </div>
+
+        <div class="status" aria-hidden="true">
+            <div class="row"><span class="dot"></span> Online</div>
+            <div class="sep"></div>
+            <div class="row">Regions <b><span id="visibleCount">0</span>/<span id="totalCount">0</span></b></div>
+            <div class="row">Providers <b>02</b></div>
+            <div class="row">Services <b>05</b></div>
+        </div>
+
+        <div class="controls">
+            <!-- Search input -->
+            <div class="search-container">
+                <div class="relative">
+                    <svg aria-hidden="true" class="search-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                    </svg>
+                    <input type="text" id="regionSearch" placeholder="Search regions…" autocomplete="off" aria-label="Search regions"
+                            role="combobox" aria-expanded="false" aria-controls="searchResults" aria-autocomplete="list" aria-activedescendant=""
+                            class="ctl ctl-search">
+                </div>
+                <div id="searchResults" role="listbox" aria-label="Search results" aria-hidden="true"></div>
+            </div>
+
+            <select id="providerFilter" aria-label="Filter by provider" class="ctl">
+                <option value="all">All Providers</option>
+                <option value="Azure">Azure</option>
+                <option value="AWS">AWS</option>
+            </select>
+
+            <div class="multiselect" id="serviceMultiselect">
+                <button type="button" id="serviceFilterBtn" aria-expanded="false" class="ctl multiselect-btn">
+                    <span id="serviceFilterLabel">All Services</span>
+                    <svg aria-hidden="true" class="multiselect-chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                    </svg>
+                </button>
+                <div class="multiselect-dropdown" id="serviceDropdown" aria-hidden="true">
+                    <label class="multiselect-option"><input type="checkbox" value="vdc_vault"> Vault</label>
+                    <label class="multiselect-option"><input type="checkbox" value="vdc_m365"> M365</label>
+                    <label class="multiselect-option"><input type="checkbox" value="vdc_entra_id"> Entra ID</label>
+                    <label class="multiselect-option"><input type="checkbox" value="vdc_salesforce"> Salesforce</label>
+                    <label class="multiselect-option"><input type="checkbox" value="vdc_azure_backup"> Azure Protection</label>
+                </div>
+            </div>
+
+            <button id="resetFilters" aria-label="Reset all filters" class="ctl ctl-reset hidden" title="Reset all filters">
+                <svg aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                </svg>
+                <span class="ctl-label">Reset</span>
+            </button>
+
+            <button id="themeToggle" aria-label="Toggle theme" class="ctl ctl-icon" title="Toggle theme">
+                <svg id="iconSystem" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/>
+                </svg>
+                <svg id="iconLight" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" class="hidden">
+                    <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"/>
+                </svg>
+                <svg id="iconDark" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" class="hidden">
+                    <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
+                </svg>
+            </button>
+
+            <button id="infoBtn" class="ctl ctl-icon" title="About this map" aria-label="Open about panel" aria-expanded="false" aria-controls="infoPanel">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+            </button>
+        </div>
+    </header>
+```
+
+Note: aria-roles and IDs (`#regionSearch`, `#providerFilter`, `#serviceDropdown`, `#themeToggle`, `#infoBtn`, `#serviceFilterLabel`, `#visibleCount`, `#totalCount`, etc.) are preserved — this keeps the existing JS event handlers and Playwright accessible-role selectors working without changes.
+
+- [ ] **Step 3: Update the `updateRegionCount` JS to use the new status strip**
+
+The new header puts `#visibleCount` and `#totalCount` inside `.status`, which is hidden on `< 900px`. That's correct — the count was already hidden on mobile in the old design. Find the existing `updateRegionCount(visible, total)` function (around line 1359). Confirm it still does `document.getElementById('visibleCount').textContent = visible;` and similar — no changes needed. If for some reason it referenced the wrapping element by a class that no longer exists, update it to just set `.textContent` on the spans by id.
+
+- [ ] **Step 4: Run the build and start dev server**
+
+```bash
+npm run build && npm run dev &
+sleep 4
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8788/
+```
+
+Expected: `200`.
+
+- [ ] **Step 5: Visual check at desktop and mobile**
+
+Open `http://localhost:8788/` in a browser. Verify:
+- Brand mark (green dot) appears at top-left with a faint pulsing ring
+- "VDC // GLOBAL TELEMETRY" tag is small uppercase above the title
+- Title reads "**Veeam** Data Cloud Service Map" with "Veeam" in accent green
+- Live "Online / Regions 72/72 / Providers 02 / Services 05" status strip is visible at ≥900px viewport
+- Controls (search, provider filter, services multiselect, theme toggle, info) sit to the right
+- At 640px viewport the status strip disappears, the brand tag hides, controls wrap to the right
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add layouts/index.html
+git commit -m "feat(ui): rebuild header with brand mark, status strip, and controls"
+```
+
+---
+
+### Task 4: Restyle controls (search, dropdowns, multi-select, buttons)
+
+**Files:**
+- Modify: `layouts/index.html` — append control styles in the `<style>` block (after the new header CSS); refine existing `.multiselect-*` and search styles.
+
+- [ ] **Step 1: Append unified control styles**
+
+After the new header CSS block from Task 3, insert:
+
+```css
+        /* === CONTROLS === */
+        .ctl {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 11px;
+            background: var(--bg-elev);
+            border: 1px solid var(--border-strong);
+            color: var(--text);
+            padding: 7px 12px;
+            border-radius: 6px;
+            cursor: pointer;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+            display: inline-flex; align-items: center; gap: 7px;
+            transition: border-color 0.15s, background 0.15s, color 0.15s;
+            line-height: 1.2;
+        }
+        .ctl:hover { border-color: var(--accent); background: var(--accent-soft); }
+        .ctl:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: 1px;
+            border-color: var(--accent);
+        }
+        .ctl svg { width: 12px; height: 12px; flex-shrink: 0; }
+        .ctl-icon { padding: 7px 9px; }
+        .ctl-icon svg { width: 14px; height: 14px; }
+        .ctl-search {
+            min-width: 200px;
+            text-transform: none;
+            letter-spacing: 0;
+            font-family: 'JetBrains Mono', monospace;
+            padding-left: 30px;
+        }
+        .ctl-search:focus { min-width: 240px; }
+        .ctl-search::placeholder { color: var(--text-dim); }
+        .ctl-reset {
+            color: var(--aws);
+            border-color: var(--aws);
+            background: transparent;
+        }
+        .ctl-reset:hover { background: var(--aws); color: var(--bg); }
+
+        .search-container { position: relative; }
+        .search-container .relative { position: relative; display: inline-block; }
+        .search-icon {
+            position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
+            width: 12px; height: 12px;
+            color: var(--text-dim);
+            pointer-events: none;
+        }
+
+        /* Searched results dropdown */
+        #searchResults {
+            position: absolute; top: calc(100% + 4px); left: 0;
+            min-width: 260px; max-height: 320px;
+            overflow-y: auto;
+            background: var(--bg-elev);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.35);
+            z-index: 1000;
+            opacity: 0; visibility: hidden; transform: translateY(-4px);
+            transition: opacity 0.15s, visibility 0.15s, transform 0.15s;
+        }
+        #searchResults.open { opacity: 1; visibility: visible; transform: translateY(0); }
+        .search-result-item {
+            display: flex; align-items: center; gap: 10px;
+            padding: 8px 12px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 12px;
+            color: var(--text);
+            background: transparent; border: none;
+            border-bottom: 1px solid var(--border);
+            width: 100%; text-align: left; cursor: pointer;
+        }
+        .search-result-item:last-child { border-bottom: none; }
+        .search-result-item:hover, .search-result-item.highlighted { background: var(--accent-soft); }
+        .search-result-item .provider-dot {
+            width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+        }
+        .search-result-item .region-name { font-weight: 500; color: var(--text); }
+        .search-result-item .match-text { font-size: 10px; color: var(--text-mute); }
+        .search-no-results {
+            padding: 12px; text-align: center; color: var(--text-mute);
+            font-family: 'JetBrains Mono', monospace; font-size: 11px;
+        }
+
+        /* Select element styling */
+        select.ctl {
+            appearance: none;
+            -webkit-appearance: none;
+            background-image: linear-gradient(45deg, transparent 50%, var(--text-mute) 50%),
+                              linear-gradient(135deg, var(--text-mute) 50%, transparent 50%);
+            background-position: calc(100% - 14px) calc(50% - 2px),
+                                 calc(100% - 9px) calc(50% - 2px);
+            background-size: 5px 5px;
+            background-repeat: no-repeat;
+            padding-right: 24px;
+        }
+
+        /* Multi-select */
+        .multiselect { position: relative; display: inline-block; }
+        .multiselect-btn { /* uses .ctl base, additional layout */ }
+        .multiselect-chevron { transition: transform 0.2s ease; }
+        .multiselect-btn[aria-expanded="true"] .multiselect-chevron { transform: rotate(180deg); }
+        .multiselect-dropdown {
+            position: absolute; top: calc(100% + 4px); right: 0;
+            min-width: 180px; max-width: calc(100vw - 16px);
+            background: var(--bg-elev);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.35);
+            z-index: 1000;
+            opacity: 0; visibility: hidden; transform: translateY(-4px);
+            transition: opacity 0.15s, visibility 0.15s, transform 0.15s;
+            overflow: hidden;
+        }
+        .multiselect-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); }
+        .multiselect-option {
+            display: flex; align-items: center; gap: 10px;
+            padding: 9px 12px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 11px;
+            color: var(--text);
+            cursor: pointer;
+            transition: background 0.12s;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+        .multiselect-option:hover { background: var(--accent-soft); }
+        .multiselect-option input[type="checkbox"] {
+            accent-color: var(--accent);
+            width: 13px; height: 13px;
+            cursor: pointer;
+        }
+
+        @media (max-width: 640px) {
+            .ctl-search { min-width: 0; flex: 1; }
+            .ctl-search:focus { min-width: 0; }
+            .ctl .ctl-label { display: none; }
+        }
+```
+
+- [ ] **Step 2: Remove the old conflicting CSS for the existing controls**
+
+Search the `<style>` block for the following old rule sets and **delete** them (they're overridden but their colors clash):
+- `select { background-color: #1e293b; … }` and `.light select { … }` (around line 85)
+- `select:hover { border-color: #00d15f … }` and `.light select:hover { … }`
+- `.multiselect-btn { … }` and `.multiselect-btn:hover { … }` (around line 107)
+- `.multiselect-dropdown { … }`, `.multiselect-dropdown.open { … }`, `.light .multiselect-dropdown { … }`
+- `.multiselect-option { … }`, `.multiselect-option:hover { … }`, `.light .multiselect-option:hover { … }`
+- `.multiselect-option input[type="checkbox"] { … }`
+- `.multiselect-chevron { … }`, `.multiselect-btn[aria-expanded="true"] .multiselect-chevron { … }`
+- `#themeToggle { … }`, `#themeToggle:hover { … }`, `#themeToggle:active { … }`
+- The whole `.search-container` / `#regionSearch` / `#searchResults` block (around lines 477–569) — replaced by the new versions in Step 1.
+
+- [ ] **Step 3: Build and visually verify**
+
+```bash
+npm run build && npm run dev &
+sleep 4
+```
+
+Open the browser. Verify:
+- Search input has the magnifier icon on the left and `Search regions…` placeholder
+- Provider filter is a clean monospace select with a chevron
+- Services filter button reads `ALL SERVICES ▾` and opens a dropdown with checkboxes (Vault / M365 / Entra ID / Salesforce / **Azure Protection**)
+- Theme toggle and info button are square icon buttons matching the others
+- Reset button (orange-bordered) appears when filters are active
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add layouts/index.html
+git commit -m "feat(ui): unify control styles into single .ctl primitive"
+```
+
+---
+
+### Task 5: Restyle map chrome (legend, loading, error) and remove old map-frame styling
+
+**Files:**
+- Modify: `layouts/index.html`
+  - CSS: replace the `#map` rule (around line 49), remove the `.dark/.light #map` glow rules, remove the `@media (max-width: 640px) #map` mobile override, add new panel rules.
+  - JS: rewrite the `legend.onAdd` function (around line 982).
+
+- [ ] **Step 1: Replace the `#map` and map-container CSS**
+
+Find the existing `#map { … }`, `@media (max-width: 640px) #map { … }`, and `.light #map { … }` rules. Replace all three with:
+
+```css
+        #map {
+            width: 100%; height: 100%;
+            background: var(--bg);
+        }
+        .map-container {
+            background: var(--bg);
+        }
+        .leaflet-container {
+            background: var(--bg);
+            font-family: 'JetBrains Mono', monospace;
+        }
+        .leaflet-control-attribution {
+            background: rgba(17, 21, 28, 0.7) !important;
+            color: var(--text-dim) !important;
+            font-size: 9px !important;
+            letter-spacing: 0.04em;
+            border-top-left-radius: 4px;
+        }
+        html.light .leaflet-control-attribution {
+            background: rgba(255, 255, 255, 0.8) !important;
+        }
+        .leaflet-control-attribution a { color: var(--text-mute) !important; }
+        .leaflet-control-zoom a {
+            background: var(--bg-elev) !important;
+            color: var(--text) !important;
+            border: 1px solid var(--border) !important;
+        }
+        .leaflet-control-zoom a:hover {
+            background: var(--accent-soft) !important;
+            border-color: var(--accent) !important;
+        }
+```
+
+Remove `border-radius: 0.75rem` and the green glow `box-shadow` from `#map` — the new design uses an edge-to-edge map with no rounded corners or glow.
+
+- [ ] **Step 2: Update `.map-container` padding so the map is edge-to-edge**
+
+Find the `<div class="map-container p-0 sm:p-4 lg:p-6 …">` (around line 686). Change the class list so the inner padding is gone on desktop too (the map should reach the window edges):
+
+```html
+    <div class="map-container bg-[var(--bg)] transition-colors duration-300 relative">
+```
+
+- [ ] **Step 3: Add panel styles (legend, coords)**
+
+Append to the `<style>` block:
+
+```css
+        /* Overlay panels on the map */
+        .panel-legend {
+            background: rgba(17, 21, 28, 0.92);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 12px 14px;
+            min-width: 170px;
+            backdrop-filter: blur(10px);
+            font-family: 'JetBrains Mono', monospace;
+            transition: transform 0.2s ease;
+        }
+        html.light .panel-legend {
+            background: rgba(255, 255, 255, 0.92);
+        }
+        .panel-legend:hover { transform: translateY(-1px); }
+        .panel-legend .label {
+            font-size: 9px; color: var(--text-dim);
+            letter-spacing: 0.18em; text-transform: uppercase;
+            margin-bottom: 10px;
+            display: flex; justify-content: space-between; align-items: center;
+        }
+        .panel-legend .label .live {
+            color: var(--accent);
+            display: inline-flex; align-items: center; gap: 4px;
+        }
+        .panel-legend .label .live::before {
+            content: ''; width: 5px; height: 5px;
+            background: var(--accent); border-radius: 50%;
+            box-shadow: 0 0 6px var(--accent-glow);
+        }
+        .panel-legend .row {
+            display: flex; align-items: center; gap: 10px;
+            margin-bottom: 6px;
+            font-size: 11px;
+            color: var(--text);
+        }
+        .panel-legend .row:last-child { margin-bottom: 0; }
+        .panel-legend .row .glyph {
+            width: 14px; height: 14px;
+            display: inline-flex; align-items: center; justify-content: center;
+            flex-shrink: 0;
+        }
+        .panel-legend .row .count {
+            margin-left: auto; color: var(--text-mute); font-size: 10px;
+        }
+```
+
+- [ ] **Step 4: Rewrite the `legend.onAdd` JS**
+
+Find the existing `legend.onAdd = function() { … }` block (around line 982). Replace its `div.innerHTML = …` with:
+
+```js
+        legend.onAdd = function() {
+            const div = L.DomUtil.create('div', 'leaflet-bar panel-legend');
+            const azureGlyph = '<svg viewBox="0 0 20 20" width="14" height="14" fill="var(--azure)"><path d="M7.3 2.5h4.7L7.2 17a.8.8 0 01-.7.5H2.8a.7.7 0 01-.7-1l4.5-13.5a.8.8 0 01.7-.5z"/><path d="M14.2 12.2H6.7a.4.4 0 00-.3.6l4.8 4.5c.1.1.3.2.5.2h4.3l-1.8-5.3z" opacity="0.7"/></svg>';
+            const awsGlyph = '<svg viewBox="0 0 24 24" width="14" height="14" fill="var(--aws)"><path d="M13.5 5.3v3.7l3.5 2-3.5 2v3.7l6.7-4.2V9.6L13.5 5.3zM10.5 5.3L3.8 9.6v3.9l6.7 4.2v-3.7l-3.5-2 3.5-2V5.3z"/></svg>';
+            div.innerHTML = `
+                <div class="label">Providers <span class="live">Live</span></div>
+                <div class="row"><span class="glyph">${azureGlyph}</span><span>Azure</span><span class="count" id="legendAzureCount"></span></div>
+                <div class="row"><span class="glyph">${awsGlyph}</span><span>AWS</span><span class="count" id="legendAwsCount"></span></div>
+            `;
+            return div;
+        };
+```
+
+- [ ] **Step 5: Populate the legend counts dynamically**
+
+Find the existing `updateRegionCount` function (around line 1359). After it sets `#visibleCount` and `#totalCount`, append:
+
+```js
+            const azureCount = regions.filter(r => r.provider === 'Azure').length;
+            const awsCount = regions.filter(r => r.provider === 'AWS').length;
+            const azureEl = document.getElementById('legendAzureCount');
+            const awsEl = document.getElementById('legendAwsCount');
+            if (azureEl) azureEl.textContent = azureCount;
+            if (awsEl) awsEl.textContent = awsCount;
+```
+
+- [ ] **Step 6: Restyle the loading and error overlays**
+
+Find the `#mapLoading` div (around line 689) and its inner content. Update its inline class to match the new aesthetic:
+
+```html
+        <div id="mapLoading" class="absolute inset-0 flex items-center justify-center z-[1000]" style="background: rgba(10, 13, 18, 0.92); backdrop-filter: blur(4px);">
+            <div class="flex flex-col items-center gap-3">
+                <svg aria-hidden="true" class="loading-spinner w-10 h-10" style="color: var(--accent);" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                <span style="color: var(--text-mute); font-family: 'JetBrains Mono', monospace; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase;">Loading…</span>
+            </div>
+        </div>
+```
+
+Update the error overlay similarly (`#mapError`, around line 699) — same background style, ink color from tokens.
+
+- [ ] **Step 7: Build, run, visually verify**
+
+```bash
+npm run build && npm run dev &
+sleep 4
+```
+
+Open the browser. Verify:
+- Map fills the available viewport edge-to-edge
+- Legend at bottom-left reads `PROVIDERS · LIVE`, `Azure · 38`, `AWS · 34` (or whatever the actual counts are)
+- Zoom controls (`+` / `−`) at bottom-right look like the other `.ctl` buttons
+- Loading spinner is green-on-dark/light depending on theme
+- No green glow around the map frame
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add layouts/index.html
+git commit -m "feat(ui): restyle map chrome and legend"
+```
+
+---
+
+### Task 6: Restructure the popup template
+
+**Files:**
+- Modify: `layouts/index.html`
+  - JS: replace the popup-build loop and `popupHTML` template (around lines 1255–1330).
+  - CSS: replace the Leaflet popup rules (around lines 192–296) with new tokenized rules.
+
+- [ ] **Step 1: Replace the Leaflet popup CSS**
+
+Find the existing block starting at `/* Leaflet popup - dark mode (default and explicit .dark) */` (around line 192) and ending after `.light .leaflet-popup-content .border-amber-500\/30 { … }` (around line 295). Replace the **entire** block with:
+
+```css
+        /* === LEAFLET POPUP === */
+        .leaflet-popup-content-wrapper {
+            background: var(--bg-elev) !important;
+            color: var(--text) !important;
+            border: 1px solid var(--border) !important;
+            padding: 0 !important;
+            border-radius: 10px !important;
+            box-shadow:
+                0 12px 40px rgba(0,0,0,0.5),
+                0 0 0 1px rgba(0,255,136,0.04) !important;
+            overflow: hidden;
+        }
+        html.light .leaflet-popup-content-wrapper {
+            box-shadow:
+                0 12px 40px rgba(15,20,25,0.10),
+                0 0 0 1px rgba(0,128,90,0.04) !important;
+        }
+        .leaflet-popup-tip {
+            background: var(--bg-elev) !important;
+            border: 1px solid var(--border) !important;
+            box-shadow: none !important;
+        }
+        .leaflet-container a.leaflet-popup-close-button {
+            color: var(--text-mute) !important;
+            font-size: 20px !important;
+            width: 28px !important;
+            height: 28px !important;
+            padding: 4px !important;
+            transition: color 0.2s, transform 0.2s;
+            top: 8px !important;
+            right: 8px !important;
+        }
+        .leaflet-container a.leaflet-popup-close-button:hover {
+            color: var(--accent) !important;
+            transform: scale(1.1);
+        }
+        .leaflet-popup-content { margin: 0 !important; width: auto !important; }
+
+        @media (max-width: 640px) {
+            .leaflet-popup-content-wrapper { max-width: calc(100vw - 40px) !important; }
+            .leaflet-popup { max-width: calc(100vw - 20px) !important; }
+        }
+
+        /* Popup inner */
+        .popup-card { width: 360px; max-width: calc(100vw - 40px); font-family: 'JetBrains Mono', monospace; }
+        .popup-head {
+            padding: 14px 16px 12px;
+            border-bottom: 1px solid var(--border);
+        }
+        .popup-region-id {
+            font-size: 9px; color: var(--text-dim);
+            letter-spacing: 0.16em; text-transform: uppercase;
+        }
+        .popup-region-name {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 19px; font-weight: 700;
+            margin-top: 4px;
+            letter-spacing: -0.01em;
+            color: var(--text);
+        }
+        .popup-region-coord {
+            font-size: 10px; color: var(--text-mute);
+            margin-top: 6px; letter-spacing: 0.04em;
+        }
+        .popup-provider-strip {
+            display: flex; align-items: center; gap: 10px;
+            padding: 9px 16px;
+            background: var(--bg-elev-2);
+            border-bottom: 1px solid var(--border);
+            font-size: 10px;
+            color: var(--text-mute);
+            text-transform: uppercase; letter-spacing: 0.12em;
+        }
+        .popup-provider-strip .pchip {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-weight: 500;
+        }
+        .popup-provider-strip .pchip.azure { color: var(--azure); }
+        .popup-provider-strip .pchip.aws { color: var(--aws); }
+        .popup-provider-strip .pchip svg { width: 11px; height: 11px; }
+        .popup-services { padding: 6px 16px 14px; }
+        .popup-svc {
+            display: grid;
+            grid-template-columns: 16px 1fr auto;
+            align-items: center; gap: 12px;
+            padding: 9px 0;
+            border-bottom: 1px solid var(--border);
+            font-size: 12px;
+        }
+        .popup-svc:last-child { border-bottom: none; }
+        .popup-svc .check { width: 14px; height: 14px; color: var(--accent); }
+        .popup-svc .name {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 500;
+            color: var(--text);
+            letter-spacing: -0.005em;
+        }
+        .popup-svc .pills {
+            display: flex; gap: 4px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 9px;
+            color: var(--text-mute);
+        }
+        .popup-svc .pill {
+            border: 1px solid var(--border-strong);
+            background: var(--bg-elev-2);
+            padding: 3px 7px;
+            border-radius: 4px;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+        }
+        .popup-svc .pill.core {
+            color: var(--accent);
+            border-color: rgba(0, 255, 136, 0.3);
+            background: rgba(0, 255, 136, 0.06);
+        }
+        html.light .popup-svc .pill.core {
+            border-color: rgba(0, 128, 90, 0.3);
+            background: rgba(0, 128, 90, 0.06);
+        }
+        .popup-svc .pill.noncore {
+            color: var(--aws);
+            border-color: rgba(255, 157, 61, 0.3);
+            background: rgba(255, 157, 61, 0.06);
+        }
+        html.light .popup-svc .pill.noncore {
+            border-color: rgba(217, 117, 6, 0.3);
+            background: rgba(217, 117, 6, 0.06);
+        }
+        .popup-svc .available {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 9px;
+            color: var(--text-mute);
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            border: 1px solid var(--border-strong);
+            padding: 3px 7px;
+            border-radius: 4px;
+            background: var(--bg-elev-2);
+        }
+```
+
+- [ ] **Step 2: Replace the popup-build JS**
+
+Find the loop that builds `iconGrid`, `serviceList`, and `popupHTML` (around lines 1257–1329). Replace the contents starting at `let iconGrid = '';` and going through the end of `popupHTML = …;` with:
+
+```js
+                    const providerKey = region.provider.toLowerCase();
+                    const providerGlyph = providerKey === 'azure'
+                        ? '<svg viewBox="0 0 20 20" fill="currentColor"><path d="M7.3 2.5h4.7L7.2 17a.8.8 0 01-.7.5H2.8a.7.7 0 01-.7-1l4.5-13.5a.8.8 0 01.7-.5z"/></svg>'
+                        : '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M13.5 5.3v3.7l3.5 2-3.5 2v3.7l6.7-4.2V9.6L13.5 5.3zM10.5 5.3L3.8 9.6v3.9l6.7 4.2v-3.7l-3.5-2 3.5-2V5.3z"/></svg>';
+
+                    let serviceRows = '';
+                    let svcCount = 0;
+
+                    if (region.services) {
+                        Object.keys(region.services).forEach(key => {
+                            const serviceValue = region.services[key];
+                            svcCount += 1;
+                            const displayName = getServiceDisplayName(key, 'full');
+
+                            const checkSvg = '<svg class="check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12l5 5L20 7"/></svg>';
+
+                            if (serviceValue === true) {
+                                serviceRows += `
+                                    <div class="popup-svc">
+                                        ${checkSvg}
+                                        <span class="name">${displayName}</span>
+                                        <span class="available">Available</span>
+                                    </div>
+                                `;
+                            } else {
+                                const configs = ensureArray(serviceValue);
+                                const pills = configs
+                                    .filter(c => c)
+                                    .map(c => {
+                                        const cls = c.tier === 'Core' ? 'pill core' : 'pill noncore';
+                                        const edition = c.edition || 'Std';
+                                        const tier = c.tier || 'N/A';
+                                        return `<span class="${cls}">${edition} · ${tier}</span>`;
+                                    })
+                                    .join('');
+                                serviceRows += `
+                                    <div class="popup-svc">
+                                        ${checkSvg}
+                                        <span class="name">${displayName}</span>
+                                        <span class="pills">${pills}</span>
+                                    </div>
+                                `;
+                            }
+                        });
+                    }
+
+                    const safeCoord = Array.isArray(region.coords)
+                        ? `${region.coords[0].toFixed(3)}°N · ${region.coords[1].toFixed(3)}°E`
+                        : '';
+                    const regionIdSlug = (region.id || region.name).toLowerCase().replace(/_/g, '-');
+
+                    const popupHTML = `
+                        <div class="popup-card">
+                            <div class="popup-head">
+                                <div class="popup-region-id">Region // ${regionIdSlug}</div>
+                                <div class="popup-region-name">${region.name}</div>
+                                <div class="popup-region-coord">${safeCoord}</div>
+                            </div>
+                            <div class="popup-provider-strip">
+                                <span class="pchip ${providerKey}">${providerGlyph} ${region.provider}</span>
+                                <span style="color:var(--text-dim)">·</span>
+                                <span>${svcCount} / 05 Services</span>
+                            </div>
+                            <div class="popup-services">${serviceRows}</div>
+                        </div>
+                    `;
+```
+
+Notes:
+- The duplicate "VAULT" row is gone — when `vdc_vault` has multiple configs they now appear as **pills** on a single row.
+- `region.coords[0].toFixed(3)` may need a null-guard if a region somehow has no coords; the existing code already filters those out at the start of the loop, so leave it.
+
+- [ ] **Step 3: Build, run, verify by clicking a region with multiple Vault editions**
+
+```bash
+npm run build && npm run dev &
+sleep 4
+```
+
+Open the browser, search for "Germany West Central" (or any Azure region with all 5 services), click it. Popup should show:
+- Region ID line: `REGION // AZURE-GERMANY-WEST-CENTRAL`
+- Big region name in Space Grotesk
+- Coordinates line
+- Provider strip with the Azure glyph in azure colour
+- One row per service: Veeam Data Cloud Vault (with two pills `Foundation · Core` and `Advanced · Core` aligned right), then Microsoft 365 Protection / Microsoft Entra ID Protection / Salesforce Protection / Microsoft Azure Protection, each with an `AVAILABLE` pill.
+
+Confirm there is **no duplicate VAULT row** anymore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add layouts/index.html
+git commit -m "feat(ui): restructure popup template; collapse vault tiers to single row"
+```
+
+---
+
+### Task 7: Replace circle markers with provider-shaped glyphs
+
+**Files:**
+- Modify: `layouts/index.html`
+  - JS: replace the `L.circleMarker(...)` call and hover handlers (around lines 1331–1346).
+  - CSS: append marker styles in the `<style>` block.
+
+- [ ] **Step 1: Append marker styles**
+
+Append to the `<style>` block:
+
+```css
+        /* === PROVIDER MARKERS === */
+        .map-marker-dot {
+            width: 22px; height: 22px;
+            position: relative;
+            display: flex; align-items: center; justify-content: center;
+            filter: drop-shadow(0 2px 6px rgba(0,0,0,0.5));
+            transition: transform 0.15s ease;
+        }
+        html.light .map-marker-dot {
+            filter: drop-shadow(0 2px 4px rgba(15,20,25,0.25));
+        }
+        .map-marker-dot.azure { color: var(--azure); }
+        .map-marker-dot.aws { color: var(--aws); }
+        .map-marker-dot:hover { transform: scale(1.18); }
+        .map-marker-dot svg { width: 100%; height: 100%; }
+```
+
+- [ ] **Step 2: Replace the marker creation block**
+
+Find the existing block starting at `const marker = L.circleMarker(region.coords, { … }).bindPopup(popupHTML);` and including the two `marker.on('mouseover'...)` / `mouseout` handlers (around lines 1331–1346). Replace it with:
+
+```js
+                    const markerIcon = L.divIcon({
+                        className: '',
+                        html: `<div class="map-marker-dot ${providerKey}">${providerGlyph}</div>`,
+                        iconSize: [22, 22],
+                        iconAnchor: [11, 11],
+                        popupAnchor: [0, -11]
+                    });
+                    const marker = L.marker(region.coords, {
+                        icon: markerIcon,
+                        keyboard: true,
+                        alt: `${region.provider} region: ${region.name}`
+                    }).bindPopup(popupHTML);
+```
+
+- [ ] **Step 3: Update Playwright test marker selector**
+
+In `tests/ui.spec.ts`, find every occurrence of `path.leaflet-interactive` and replace with `.leaflet-marker-icon .map-marker-dot` (the new selector that picks up our glyph divs):
+
+```bash
+grep -n "path.leaflet-interactive" tests/ui.spec.ts
+```
+
+Replace each with:
+
+```typescript
+const markers = page.locator('.leaflet-marker-icon .map-marker-dot');
+```
+
+- [ ] **Step 4: Build, run, visually verify**
+
+```bash
+npm run build && npm run dev &
+sleep 4
+```
+
+Open the browser. Verify:
+- All markers are now small Azure-blue triangle or AWS-orange cube icons (NOT circles)
+- Hovering a marker scales it slightly
+- Clicking a marker opens the redesigned popup
+- Marker clusters at low zoom still group correctly (the cluster icons themselves are not yet restyled — that's deliberate; cluster restyling is out of scope for this redesign and the existing styling remains)
+
+- [ ] **Step 5: Run the Playwright tests**
+
+```bash
+npm run test:ui
+```
+
+Expected: tests that previously used `path.leaflet-interactive` now pass with the new `.leaflet-marker-icon .map-marker-dot` selector. If any test fails for other reasons (e.g. label text), note the failure for the next task.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add layouts/index.html tests/ui.spec.ts
+git commit -m "feat(ui): replace circle markers with provider-shaped glyph icons"
+```
+
+---
+
+### Task 8: Update service display names, multi-select Azure rename, and initial map center
+
+**Files:**
+- Modify: `layouts/index.html`
+  - JS: update `serviceDisplayNames` (around line 928–934).
+  - JS: change `center: [-25, 140]` to a globally-balanced default (around line 962).
+  - HTML: the multi-select option "Azure" was already renamed to "Azure Protection" in Task 3 — verify it.
+
+- [ ] **Step 1: Update `serviceDisplayNames`**
+
+Find the existing `serviceDisplayNames` constant (around line 928). Replace its body with:
+
+```js
+        const serviceDisplayNames = {
+            'vdc_vault':         { short: 'Vault',             full: 'Veeam Data Cloud Vault' },
+            'vdc_m365':          { short: 'M365',              full: 'Microsoft 365 Protection' },
+            'vdc_entra_id':      { short: 'Entra ID',          full: 'Microsoft Entra ID Protection' },
+            'vdc_salesforce':    { short: 'Salesforce',        full: 'Salesforce Protection' },
+            'vdc_azure_backup':  { short: 'Azure Protection',  full: 'Microsoft Azure Protection' }
+        };
+```
+
+These `full` names match the section headings in the official Veeam Data Cloud help-center user guide. `short` names appear in the filter-dropdown checkbox labels and the filter-button label (e.g. when only one service is selected). Note the `short` for `vdc_azure_backup` is now "Azure Protection" — this removes the collision with the "Azure" provider while staying aligned with the official "…Protection" naming.
+
+- [ ] **Step 2: Update initial map center**
+
+Find the `L.map('map', { … })` call (around line 961). Change `center: [-25, 140]` to `center: [25, 10]` and `zoom: 3` to `zoom: 2`:
+
+```js
+        map = L.map('map', {
+            center: [25, 10],
+            minZoom: 2.0,
+            maxZoom: 6.0,
+            zoom: 2,
+            zoomControl: false,
+            worldCopyJump: true,
+            maxBoundsViscosity: 1.0,
+            maxBounds: [[-60, -185], [90, 185]],
+            fadeAnimation: !reducedMotion,
+            zoomAnimation: !reducedMotion,
+            markerZoomAnimation: !reducedMotion
+        });
+```
+
+The new center `[25, 10]` puts Africa/Europe roughly in the centre of the viewport; at zoom 2, all continents are visible.
+
+- [ ] **Step 3: Update Playwright test labels for the renamed Azure service**
+
+The service-filter checkbox label is now "Azure Protection" (not "Azure"). Find each reference in `tests/ui.spec.ts`:
+
+```bash
+grep -n "name: 'Azure'" tests/ui.spec.ts
+```
+
+For each match where the context is a service-filter **checkbox** (not a provider-filter option), replace `name: 'Azure'` with `name: 'Azure Protection'`. Be careful — there's also a provider-filter test that checks `name: /azure/i` for the dropdown option; that one should remain since the provider's option is still labelled "Azure". Inspect each match's surrounding code to disambiguate before editing.
+
+- [ ] **Step 4: Run Playwright tests again to confirm green**
+
+```bash
+npm run test:ui
+```
+
+Expected: all UI tests pass.
+
+- [ ] **Step 5: Build and visually verify**
+
+```bash
+npm run build && npm run dev &
+sleep 4
+```
+
+Open the browser. Verify:
+- Initial view shows Africa centred; Europe, Americas, Asia all visible
+- Service filter dropdown lists "Vault / M365 / Entra ID / Salesforce / Azure Protection"
+- Popup row names match the official help-center names: "Veeam Data Cloud Vault", "Microsoft 365 Protection", "Microsoft Entra ID Protection", "Salesforce Protection", "Microsoft Azure Protection"
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add layouts/index.html tests/ui.spec.ts
+git commit -m "feat(ui): adopt official Veeam help-center service names; fix initial map center"
+```
+
+---
+
+### Task 9: Restyle the info panel (slide-out)
+
+**Files:**
+- Modify: `layouts/index.html` — info panel CSS (around lines 322–360) and HTML (around lines 718–844).
+
+- [ ] **Step 1: Update info panel container CSS**
+
+Find the existing `#infoPanel { … }` rule (around line 322). Replace it (and its `.dark`/`.light` siblings, plus `#infoPanelOverlay.open`, `#infoPanel.open`) with:
+
+```css
+        /* Info panel slide-out */
+        #infoPanel {
+            scrollbar-width: thin;
+            scrollbar-color: var(--border-strong) transparent;
+            transform: translateX(100%);
+            transition: transform 0.28s cubic-bezier(0.25, 1, 0.5, 1);
+            background: var(--bg-elev);
+            border-left: 1px solid var(--border);
+            color: var(--text);
+            font-family: 'JetBrains Mono', monospace;
+        }
+        #infoPanel::-webkit-scrollbar { width: 6px; }
+        #infoPanel::-webkit-scrollbar-track { background: transparent; }
+        #infoPanel::-webkit-scrollbar-thumb {
+            background: var(--border-strong);
+            border-radius: 3px;
+        }
+        #infoPanel.open { transform: translateX(0); }
+        #infoPanelOverlay.open { opacity: 1; }
+        #infoBtn { /* uses .ctl-icon */ }
+```
+
+- [ ] **Step 2: Update info panel HTML content classes**
+
+The info panel content is the largest single chunk to retoken. Find the `<div id="infoPanel" …>` (around line 720) and walk down to its closing `</div>` (around line 844). Update class attributes so colors come from tokens rather than Tailwind slate-* utilities:
+
+Replace the entire `<div id="infoPanel" …>` element with:
+
+```html
+<div id="infoPanel" class="fixed top-0 right-0 h-full w-full sm:w-96 max-w-full shadow-2xl z-[2001] overflow-y-auto" role="dialog" aria-modal="true" aria-labelledby="infoPanelTitle">
+    <div class="p-5" style="padding-top: calc(1.25rem + env(safe-area-inset-top));">
+        <div class="flex items-center justify-between mb-4">
+            <h2 id="infoPanelTitle" class="font-bold" style="font-family: 'Space Grotesk', sans-serif; font-size: 22px; letter-spacing: -0.01em;">About This Map</h2>
+            <button id="closeInfoPanel" class="ctl ctl-icon" aria-label="Close panel">
+                <svg aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                </svg>
+            </button>
+        </div>
+
+        <div class="info-callout">
+            <svg aria-hidden="true" class="info-callout-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+            </svg>
+            <div>
+                <p class="info-callout-title">Community Project</p>
+                <p class="info-callout-body">This is an unofficial, community-maintained project. Not affiliated with or endorsed by Veeam Software. Data may be incomplete or outdated.</p>
+            </div>
+        </div>
+
+        <div class="info-section">
+            <h3 class="info-section-label">What is this?</h3>
+            <p class="info-section-body">An interactive map visualizing Veeam Data Cloud (VDC) service availability across AWS and Azure regions. Quickly find where services like Veeam Data Cloud Vault, Microsoft 365 Protection, and more are available.</p>
+        </div>
+
+        <div class="info-stats">
+            <div class="info-stat">
+                <div class="info-stat-num" id="infoTotalRegions">0</div>
+                <div class="info-stat-label">Total Regions</div>
+            </div>
+            <div class="info-stat">
+                <div class="info-stat-num">5</div>
+                <div class="info-stat-label">Services Tracked</div>
+            </div>
+        </div>
+
+        <div class="info-section">
+            <h3 class="info-section-label">Maintained By</h3>
+            <a href="https://github.com/comnam90" target="_blank" rel="noopener noreferrer" class="info-link info-link-card">
+                <div class="info-avatar">C</div>
+                <div>
+                    <div class="info-link-name">@comnam90</div>
+                    <div class="info-link-sub">GitHub</div>
+                </div>
+                <svg aria-hidden="true" class="info-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+            </a>
+        </div>
+
+        <div class="info-section">
+            <h3 class="info-section-label">Quick Links</h3>
+            <div class="info-link-group">
+                <a href="https://github.com/comnam90/veeam-data-cloud-services-map" target="_blank" rel="noopener noreferrer" class="info-link">
+                    <svg aria-hidden="true" class="info-link-icon" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                    <span>View on GitHub</span>
+                    <svg aria-hidden="true" class="info-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                </a>
+                <a href="/api/docs" target="_blank" rel="noopener noreferrer" class="info-link">
+                    <svg aria-hidden="true" class="info-link-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg>
+                    <span>API Documentation</span>
+                    <svg aria-hidden="true" class="info-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                </a>
+                <a href="https://www.veeam.com/products/veeam-data-cloud.html" target="_blank" rel="noopener noreferrer" class="info-link">
+                    <svg aria-hidden="true" class="info-link-icon" style="color: var(--accent);" fill="currentColor" viewBox="0 0 144 144"><path d="M118.21 117.2c0 .49-.2.94-.53 1.27-.33.32-.77.53-1.27.53l-21.51.11v12.01H105c3.21 0 6.3-1.28 8.57-3.55l13.2-13.2c2.27-2.27 3.55-5.36 3.55-8.57V94.65h-12.11v22.56zM25.79 26.8c0-.49.2-.94.53-1.27.32-.32.77-.53 1.27-.53l21.51-.11V12.88H39c-3.21 0-6.3 1.28-8.57 3.55l-13.2 13.2a12.14 12.14 0 0 0-3.55 8.57v11.15h12.11V26.79zm-.47 90.68a1.8 1.8 0 0 1-.52-1.27l-.11-21.51H12.68v10.1c0 3.21 1.28 6.3 3.55 8.57l13.2 13.2c2.27 2.27 5.36 3.55 8.57 3.55h11.15v-12.11H26.59c-.49-.01-.94-.21-1.27-.54zm102.46-86.86-13.2-13.2a12.14 12.14 0 0 0-8.57-3.55H94.86v12.11h22.56c.49.01.94.21 1.27.54.32.32.52.77.52 1.27l.11 21.51h12.01V39.2c0-3.21-1.28-6.3-3.55-8.57zM71.86 78.79a6.65 6.65 0 1 0 0-13.3 6.65 6.65 0 0 0 0 13.3"/></svg>
+                    <span>Official Veeam Data Cloud</span>
+                    <svg aria-hidden="true" class="info-arrow" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                </a>
+            </div>
+        </div>
+
+        <div class="info-section">
+            <h3 class="info-section-label">Found an Issue?</h3>
+            <div class="info-link-group">
+                <a href="https://github.com/comnam90/veeam-data-cloud-services-map/issues/new?template=missing-service.yml" target="_blank" rel="noopener noreferrer" class="info-link info-link-accent">
+                    <svg aria-hidden="true" class="info-link-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                    <span>Report Missing Service</span>
+                </a>
+                <a href="https://github.com/comnam90/veeam-data-cloud-services-map/issues/new?template=missing-region.yml" target="_blank" rel="noopener noreferrer" class="info-link info-link-accent">
+                    <svg aria-hidden="true" class="info-link-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+                    <span>Report Missing Region</span>
+                </a>
+                <a href="https://github.com/comnam90/veeam-data-cloud-services-map/issues/new?template=incorrect-information.yml" target="_blank" rel="noopener noreferrer" class="info-link info-link-accent">
+                    <svg aria-hidden="true" class="info-link-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+                    <span>Report Incorrect Info</span>
+                </a>
+            </div>
+        </div>
+
+        <div class="info-footer">
+            {{ with .GitInfo }}
+            <p>Last updated: {{ now.Format "January 2, 2006" }}</p>
+            {{ end }}
+            <p>Built with Hugo, Leaflet.js &amp; Tailwind CSS</p>
+        </div>
+    </div>
+</div>
+```
+
+- [ ] **Step 3: Add info panel content CSS**
+
+Append to the `<style>` block:
+
+```css
+        /* Info panel content */
+        .info-callout {
+            display: flex; gap: 10px;
+            padding: 12px 14px;
+            border-radius: 8px;
+            border: 1px solid var(--accent);
+            background: var(--accent-soft);
+            margin-bottom: 16px;
+        }
+        .info-callout-icon { width: 18px; height: 18px; color: var(--accent); flex-shrink: 0; margin-top: 2px; }
+        .info-callout-title {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--accent);
+            margin-bottom: 4px;
+        }
+        .info-callout-body {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 11px;
+            color: var(--text-mute);
+            line-height: 1.5;
+        }
+        .info-section { margin-bottom: 20px; }
+        .info-section-label {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 10px;
+            color: var(--text-dim);
+            text-transform: uppercase;
+            letter-spacing: 0.18em;
+            margin-bottom: 10px;
+        }
+        .info-section-body {
+            font-family: 'Space Grotesk', sans-serif;
+            font-size: 14px;
+            color: var(--text);
+            line-height: 1.5;
+        }
+        .info-stats { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 20px; }
+        .info-stat {
+            background: var(--bg-elev-2);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 12px;
+        }
+        .info-stat-num {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 700;
+            font-size: 24px;
+            color: var(--text);
+            letter-spacing: -0.02em;
+        }
+        .info-stat-label {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 10px;
+            color: var(--text-mute);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            margin-top: 4px;
+        }
+        .info-link-group { display: flex; flex-direction: column; gap: 6px; }
+        .info-link {
+            display: flex; align-items: center; gap: 10px;
+            padding: 10px 12px;
+            background: var(--bg-elev-2);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 12px;
+            color: var(--text);
+            text-decoration: none;
+            transition: border-color 0.15s, background 0.15s;
+        }
+        .info-link:hover { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); }
+        .info-link-icon { width: 16px; height: 16px; flex-shrink: 0; color: var(--text-mute); }
+        .info-link:hover .info-link-icon { color: var(--accent); }
+        .info-link span { flex: 1; }
+        .info-arrow { width: 12px; height: 12px; color: var(--text-dim); }
+        .info-link-card { gap: 12px; padding: 10px 12px; }
+        .info-avatar {
+            width: 32px; height: 32px;
+            border-radius: 50%;
+            background: var(--accent);
+            color: var(--bg);
+            display: flex; align-items: center; justify-content: center;
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 700;
+            font-size: 13px;
+            flex-shrink: 0;
+        }
+        .info-link-name {
+            font-family: 'Space Grotesk', sans-serif;
+            font-weight: 500;
+            font-size: 13px;
+            color: var(--text);
+        }
+        .info-link-sub {
+            font-size: 10px;
+            color: var(--text-mute);
+            margin-top: 2px;
+            letter-spacing: 0.04em;
+        }
+        .info-link-accent .info-link-icon { color: var(--accent); }
+        .info-footer {
+            padding-top: 16px;
+            border-top: 1px solid var(--border);
+            text-align: center;
+        }
+        .info-footer p {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 10px;
+            color: var(--text-dim);
+            margin-bottom: 4px;
+            letter-spacing: 0.04em;
+        }
+```
+
+- [ ] **Step 4: Build, run, verify the info panel**
+
+```bash
+npm run build && npm run dev &
+sleep 4
+```
+
+Open the browser, click the (i) info button in the header. The panel slides in from the right. Verify:
+- "About This Map" title in Space Grotesk
+- Community Project callout uses the green accent border
+- Stats cards show region counts
+- Quick Links cards turn green-bordered on hover
+- "Found an Issue?" cards use the green accent border throughout (no purple/blue/amber mix)
+- Footer text in mono
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add layouts/index.html
+git commit -m "feat(ui): retoken info panel content"
+```
+
+---
+
+### Task 10: Final cleanup of old CSS and visual verification at both themes / viewports
+
+**Files:**
+- Modify: `layouts/index.html` — delete leftover unused CSS from prior design.
+
+- [ ] **Step 1: Search the `<style>` block for unused rules**
+
+Run a grep for any remaining hardcoded slate colours that were used by the old design but are no longer applied to live elements:
+
+```bash
+grep -nE "bg-slate-|text-slate-|border-slate-|#0f172a|#1e293b|#334155|#475569" layouts/index.html | head -40
+```
+
+For each match, check whether the CSS class is still used by an element in the new design. The map / overlay / Tailwind utilities you keep should be: any class that styles `info-*`, `popup-*`, `panel-*`, `ctl*`, `hud`, `status`, `brand`, `map-marker-dot`. Anything else that was specifically targeting old class names (`.header-gradient`, `.legend-container` selectors not used anymore) can be deleted.
+
+This is housekeeping — leftover unused CSS is harmless but adds bytes. Aim to remove at least the dead `.header-gradient`, `.legend-container` (replaced by `.panel-legend`), and any `.dark` / `.light` selectors that target classes which no longer exist.
+
+- [ ] **Step 2: Run typecheck + full build + all tests**
+
+```bash
+npm run typecheck
+npm run build
+npm run test:validate
+npm run test:ui
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Manual verification at both themes and viewports**
+
+Start the dev server:
+
+```bash
+npm run dev &
+sleep 4
+```
+
+Use Chrome (or a manual browser) to verify each of the four states:
+
+1. **Desktop dark (1440×900):** Open `http://localhost:8788/`. Expect: globally-centred map, status strip visible with `Online · Regions 72/72 · Providers 02 · Services 05`, marker glyphs (blue triangles for Azure, orange cubes for AWS), green pulse on the brand mark. Click a multi-service region — popup shows one row per service, Vault row has both edition pills.
+
+2. **Desktop light (1440×900):** Click the theme toggle. Expect: cool-off-white background, same content/layout, accent is now muted green, AWS marker is darker orange.
+
+3. **Mobile dark (393×852):** Open Chrome DevTools, switch to iPhone 15 Pro emulation. Expect: status strip hidden, controls wrap, marker popup fits within `calc(100vw - 40px)`, info panel takes full width when opened.
+
+4. **Mobile light (393×852):** Toggle theme. Same checks.
+
+Capture a screenshot for each of the four states and inspect for issues:
+- No console errors
+- No layout overflow (`document.documentElement.scrollWidth === window.innerWidth`)
+- No flash of unstyled content on load
+- Theme toggle persists across reloads (localStorage check)
+- Reduced-motion users don't see the pulse on the brand mark — but this is fine, the existing `@media (prefers-reduced-motion: reduce)` rule already overrides it.
+
+- [ ] **Step 4: Commit any cleanup changes**
+
+```bash
+git add layouts/index.html
+git commit -m "chore(ui): remove unused old-design CSS"
+```
+
+- [ ] **Step 5: Open a PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "feat(ui): mission control redesign" --body "$(cat <<'EOF'
+## Summary
+
+- Redesigns the SPA with a paired dark / light "Mission Control / Workstation" aesthetic
+- Replaces generic SaaS look with characterful Space Grotesk + JetBrains Mono typography
+- Restructures popup: one row per service, edition pills aligned right (fixes Vault duplication)
+- Replaces circle markers with provider-shaped glyphs
+- Adopts the official Veeam help-center service names: Veeam Data Cloud Vault, Microsoft 365 Protection, Microsoft Entra ID Protection, Salesforce Protection, Microsoft Azure Protection
+- Renames the "Azure" service filter to "Azure Protection" to remove collision with the Azure provider
+- Fixes initial map centre (Australia → globally-balanced)
+- Adds live data strip in the header (Online indicator, region count, provider/service counts)
+- Both themes are first-class — same layout, same components, theme tokens only
+
+## Test plan
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm run build` passes
+- [ ] `npm run test:ui` — all Playwright tests pass after marker selector + "Azure Protection" label updates
+- [ ] Desktop dark — manual check
+- [ ] Desktop light — manual check
+- [ ] Mobile dark (iPhone 15 Pro) — manual check
+- [ ] Mobile light — manual check
+- [ ] Theme toggle persists across reload
+- [ ] Popup shows Vault edition pills correctly when both Foundation and Advanced are present in a region
+- [ ] Reduced-motion preference suppresses the brand mark pulse
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** — Each item from the agreed scope ("Full redesign to A-v2 + A-2") is covered:
+
+| Spec item | Covered by |
+|---|---|
+| Typography (Space Grotesk + JetBrains Mono) | Task 2 |
+| Color tokens (dark + light) | Task 2 |
+| Header restructure | Task 3 |
+| Controls restyle | Task 4 |
+| Popup restructure | Task 6 |
+| Glyph markers | Task 7 |
+| Status strip | Task 3 |
+| Both themes | All tasks via `:root` + `html.light` tokens |
+| Map chrome (no brackets/grid/scan-line) | Task 5 |
+| Mobile breakpoints | Distributed (Task 3 hud, Task 4 controls, Task 6 popup, Task 9 info panel) |
+| Vault duplication fix | Task 6 |
+| Service display names | Task 8 |
+| Initial map center | Task 8 |
+| Supersede old plan | Task 1 |
+
+**Placeholder scan** — No TBDs, no "Add appropriate error handling", no "implement later", no "similar to Task N" without showing the code. Every CSS block, JS replacement, and HTML chunk is given in full.
+
+**Type consistency** — Reviewed: `providerKey`, `serviceDisplayNames`, `popupHTML`, `markerIcon` are used consistently across Tasks 6, 7, 8. Marker selector `.leaflet-marker-icon .map-marker-dot` is used identically in the JS (Task 7) and Playwright tests (Task 7 Step 3).
+
+**Other notes for the executing engineer:**
+
+- The `info-section .info-section-body` uses Space Grotesk (sans-serif) but the rest of body copy is JetBrains Mono. This is intentional — body prose reads better in proportional type while UI labels stay mono.
+- Cluster styling (`.cluster-small`, `.cluster-medium`, `.cluster-large`) is left untouched on purpose. A redesign of clusters belongs to a follow-up; the current cluster pulse and provider-stripe indicator works fine with the new marker glyphs.
+- If `npm run test:ui` flakes on WebKit due to existing Leaflet instability (CLAUDE.md notes this), use `--project=chromium` for the verification run.
+- Hugo's `{{ with .GitInfo }}…{{ end }}` in the info-panel footer remains untouched — it must still render at build time.

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -60,14 +60,14 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
 | provider | string | No | AWS, Azure | Filter by cloud provider. Omit to see both. |
 | country | string | No | Any string | Search by country or location name. Matches region names and aliases (e.g., "Japan" finds Tokyo). Case-insensitive partial matching. |
 | service | string | No | vdc_vault, vdc_m365, vdc_entra_id, vdc_salesforce, vdc_azure_backup | Show only regions where this service is available. |
-| tier | string | No | Core, Non-Core | Filter VDC Vault by pricing tier. Only applies to vdc_vault service. |
-| edition | string | No | Foundation, Advanced | Filter VDC Vault by edition. Only applies to vdc_vault service. |
+| tier | string | No | Core, Non-Core | Filter Veeam Data Cloud Vault by pricing tier. Only applies to vdc_vault service. |
+| edition | string | No | Foundation, Advanced | Filter Veeam Data Cloud Vault by edition. Only applies to vdc_vault service. |
 
 **Filtering Logic:**
 - All parameters are optional and can be combined
 - Multiple filters use AND logic (all must match)
 - Country search is case-insensitive and supports partial matching
-- Tier and edition filters only affect VDC Vault results
+- Tier and edition filters only affect Veeam Data Cloud Vault results
 - Empty/no filters return all 63 regions
 
 **Response Schema:**
@@ -113,7 +113,7 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
    GET /api/v1/regions?service=vdc_m365
    ```
 
-3. **AWS regions with VDC Vault Advanced/Core:**
+3. **AWS regions with Veeam Data Cloud Vault Advanced/Core:**
    ```
    GET /api/v1/regions?provider=AWS&service=vdc_vault&edition=Advanced&tier=Core
    ```
@@ -578,7 +578,7 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
     },
     {
       "id": "vdc_m365",
-      "name": "VDC for Microsoft 365",
+      "name": "Microsoft 365 Protection",
       "type": "boolean",
       "description": "Backup and recovery for Microsoft 365 data",
       "regionCount": 23,
@@ -589,9 +589,9 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
     },
     {
       "id": "vdc_entra_id",
-      "name": "VDC for Entra ID",
+      "name": "Microsoft Entra ID Protection",
       "type": "boolean",
-      "description": "Backup and recovery for Microsoft Entra ID (Azure AD)",
+      "description": "Backup and recovery for Microsoft Entra ID (formerly Azure AD)",
       "regionCount": 23,
       "providerBreakdown": {
         "AWS": 0,
@@ -600,7 +600,7 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
     },
     {
       "id": "vdc_salesforce",
-      "name": "VDC for Salesforce",
+      "name": "Salesforce Protection",
       "type": "boolean",
       "description": "Backup and recovery for Salesforce data",
       "regionCount": 12,
@@ -611,7 +611,7 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
     },
     {
       "id": "vdc_azure_backup",
-      "name": "VDC for Azure",
+      "name": "Microsoft Azure Protection",
       "type": "boolean",
       "description": "Native Azure backup capabilities",
       "regionCount": 36,
@@ -634,25 +634,25 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
 
 **Service Details:**
 
-1. **VDC Vault** (vdc_vault)
+1. **Veeam Data Cloud Vault** (vdc_vault)
    - Type: Tiered
    - Purpose: Object storage backup repository
    - Editions: Foundation (entry-level), Advanced (full-featured)
    - Tiers: Core (premium performance), Non-Core (cost-optimized)
 
-2. **VDC for Microsoft 365** (vdc_m365)
+2. **Microsoft 365 Protection** (vdc_m365)
    - Type: Boolean
    - Purpose: Backup for Exchange Online, SharePoint Online, OneDrive, Teams
 
-3. **VDC for Entra ID** (vdc_entra_id)
+3. **Microsoft Entra ID Protection** (vdc_entra_id)
    - Type: Boolean
-   - Purpose: Azure Active Directory backup
+   - Purpose: Microsoft Entra ID (formerly Azure AD) backup
 
-4. **VDC for Salesforce** (vdc_salesforce)
+4. **Salesforce Protection** (vdc_salesforce)
    - Type: Boolean
    - Purpose: Salesforce CRM data protection
 
-5. **VDC for Azure** (vdc_azure_backup)
+5. **Microsoft Azure Protection** (vdc_azure_backup)
    - Type: Boolean
    - Purpose: Azure VM and resource backup
 
@@ -661,8 +661,8 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
 
 **Use Cases:**
 
-1. **Compare service availability**: Quickly see that VDC Vault has 80 regions while VDC for Salesforce has only 12
-2. **Understand provider distribution**: See that M365/Entra ID are Azure-only while VDC Vault spans both providers
+1. **Compare service availability**: Quickly see that Veeam Data Cloud Vault has 80 regions while Salesforce Protection has only 12
+2. **Understand provider distribution**: See that M365/Entra ID are Azure-only while Veeam Data Cloud Vault spans both providers
 3. **Configuration planning**: Check configurationBreakdown to see how many regions support Advanced-Core tier
 
 ---
@@ -691,7 +691,7 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
 {
   "service": {
     "id": "vdc_m365",
-    "name": "VDC for Microsoft 365",
+    "name": "Microsoft 365 Protection",
     "type": "boolean",
     "description": "Backup and recovery for Microsoft 365 data",
     "regionCount": 23
@@ -797,7 +797,7 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
    GET /api/v1/services/vdc_m365
    ```
 
-2. **Get VDC Vault distribution:**
+2. **Get Veeam Data Cloud Vault distribution:**
    ```
    GET /api/v1/services/vdc_vault
    ```
@@ -833,7 +833,7 @@ This API provides programmatic access to comprehensive data about Veeam Data Clo
 
 1. **List all regions for a service**: Use the `regions` array to get all region IDs
 2. **Find provider-specific regions**: Check `providerBreakdown.AWS.regions` or `providerBreakdown.Azure.regions`
-3. **Configuration-specific planning**: For VDC Vault, use `configurationBreakdown["Advanced-Core"].regions` to find regions supporting specific configurations
+3. **Configuration-specific planning**: For Veeam Data Cloud Vault, use `configurationBreakdown["Advanced-Core"].regions` to find regions supporting specific configurations
 4. **Build deployment matrices**: Combine with `/api/v1/regions/{id}` to get full geographic details for each region
 
 ---
@@ -960,7 +960,7 @@ interface VaultService {
 
 **Understanding Service Data:**
 
-1. **Tiered Service (VDC Vault)**:
+1. **Tiered Service (Veeam Data Cloud Vault)**:
    - Represented as array of edition/tier combinations
    - Region may offer multiple combinations
    - Example: `[{edition: "Foundation", tier: "Core"}, {edition: "Advanced", tier: "Core"}]`
@@ -1036,7 +1036,7 @@ Step 3: Select region based on geography/latency
 ```
 Step 1: GET /api/v1/regions/aws-us-east-1
 Step 2: Check services object for required service
-Step 3: Verify edition/tier if using VDC Vault
+Step 3: Verify edition/tier if using Veeam Data Cloud Vault
 ```
 
 #### 4. Find Nearest Region with Required Service
@@ -1184,7 +1184,7 @@ Action: Replace 'GCP' with 'AWS' or 'Azure' and retry
 
 ### Service Availability Rules
 
-1. **VDC Vault (Tiered Service)**
+1. **Veeam Data Cloud Vault (Tiered Service)**
    - Can have multiple edition/tier combinations per region
    - Not all combinations available in all regions
    - Typical pattern: both editions in Core tier, fewer in Non-Core
@@ -1207,12 +1207,12 @@ When multiple filters are applied:
 ```
 AND logic: ALL conditions must be met
 Example: provider=AWS&service=vdc_vault&tier=Core
-Returns: AWS regions that have VDC Vault with Core tier
+Returns: AWS regions that have Veeam Data Cloud Vault with Core tier
 ```
 
 Special cases:
-- `tier` without `service` - filters only VDC Vault
-- `edition` without `service` - filters only VDC Vault
+- `tier` without `service` - filters only Veeam Data Cloud Vault
+- `edition` without `service` - filters only Veeam Data Cloud Vault
 - Empty result set is valid (no matching regions)
 
 ### Data Freshness
@@ -1437,7 +1437,7 @@ async function getServiceRegionDetails(serviceId) {
   const serviceResp = await fetch(`/api/v1/services/${serviceId}`);
   const serviceData = await serviceResp.json();
 
-  // For VDC Vault, find regions supporting Advanced-Core
+  // For Veeam Data Cloud Vault, find regions supporting Advanced-Core
   if (serviceId === 'vdc_vault' && serviceData.configurationBreakdown) {
     const advancedCoreRegions = serviceData.configurationBreakdown['Advanced-Core'].regions;
 
@@ -1462,7 +1462,7 @@ const coverage = await analyzeServiceCoverage();
 console.log('Service coverage analysis:', coverage);
 
 const vaultRegions = await getServiceRegionDetails('vdc_vault');
-console.log('VDC Vault Advanced-Core regions:', vaultRegions);
+console.log('Veeam Data Cloud Vault Advanced-Core regions:', vaultRegions);
 ```
 
 ### Example 6: Building Region Selector UI
@@ -1537,7 +1537,7 @@ console.log(`Loaded ${stats.totalRegions} regions`);
    - Check for property existence before accessing
    - Absent property typically means service not available
 
-2. **VDC Vault is Special**
+2. **Veeam Data Cloud Vault is Special**
    - Only service with tiered availability
    - Returns array, not boolean
    - Can have 0, 1, or multiple edition/tier combinations

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -23,15 +23,15 @@ This API provides comprehensive information about which Veeam Data Cloud (VDC) s
 ```
 GET /api/v1/regions?provider=AWS&service=vdc_vault&tier=Core
 ```
-Returns all AWS regions offering VDC Vault in Core pricing tier.
+Returns all AWS regions offering Veeam Data Cloud Vault in Core pricing tier.
 
 ## VDC Services Covered
 
-1. **VDC Vault** - Object storage backup repository (tiered: Foundation/Advanced, Core/Non-Core)
-2. **VDC for Microsoft 365** - Backup for Exchange, SharePoint, OneDrive, Teams
-3. **VDC for Entra ID** - Azure Active Directory backup
-4. **VDC for Salesforce** - CRM data protection
-5. **VDC for Azure** - Azure VM and resource backup
+1. **Veeam Data Cloud Vault** (`vdc_vault`) - Object storage backup repository (tiered: Foundation/Advanced, Core/Non-Core)
+2. **Microsoft 365 Protection** (`vdc_m365`) - Backup for Exchange, SharePoint, OneDrive, Teams
+3. **Microsoft Entra ID Protection** (`vdc_entra_id`) - Microsoft Entra ID (formerly Azure AD) backup
+4. **Salesforce Protection** (`vdc_salesforce`) - CRM data protection
+5. **Microsoft Azure Protection** (`vdc_azure_backup`) - Azure VM and resource backup
 
 ## Common Use Cases
 

--- a/tests/ui.spec.ts
+++ b/tests/ui.spec.ts
@@ -91,6 +91,67 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       
       await expect(popup).toContainText(/East US 2|Virginia/i);
     });
+
+    test('NZ popup fits inside mobile viewport when zoomed in (regression: east-bound cutoff)', async ({ page }, testInfo) => {
+      const mobilePlatforms = ['Mobile Chrome', 'Mobile Safari'];
+      test.skip(!mobilePlatforms.includes(testInfo.project.name), 'Mobile-only regression: at low zoom the popup can\'t fit geometrically regardless of bounds');
+      test.skip(testInfo.project.name === 'webkit' && process.platform === 'linux', 'Leaflet map navigation causes webkit instability on Linux');
+
+      // Simulate the user's reported flow: they "zoom in a lot" to view NZ, then tap the marker.
+      // setView via the exposed map global so the test is deterministic.
+      const NZ_COORDS: [number, number] = [-36.8485, 174.7633];
+      const markerPoint = await page.evaluate((coords) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const m = (window as any).__map;
+        // Zoom 4: at this level on a 412px viewport, the old maxBounds east edge (+185)
+        // forced the NZ marker ~88px right of viewport center, causing the centered popup
+        // to overflow ~77px past the right edge. Extending the bound east lets the marker
+        // sit at center and the popup fit.
+        m.setView(coords, 4, { animate: false });
+        const c = m.latLngToContainerPoint(coords);
+        const r = m.getContainer().getBoundingClientRect();
+        return { x: r.left + c.x, y: r.top + c.y };
+      }, NZ_COORDS);
+
+      await page.mouse.click(markerPoint.x, markerPoint.y);
+      const popup = page.locator('.leaflet-popup');
+      await expect(popup).toBeVisible({ timeout: 5000 });
+      // Let autoPan animation settle before measuring.
+      await page.waitForTimeout(500);
+
+      const box = await popup.boundingBox();
+      const vp = page.viewportSize();
+      expect(box).not.toBeNull();
+      expect(vp).not.toBeNull();
+      expect(box!.x).toBeGreaterThanOrEqual(0);
+      expect(box!.y).toBeGreaterThanOrEqual(0);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(vp!.width);
+      expect(box!.y + box!.height).toBeLessThanOrEqual(vp!.height);
+    });
+
+    test('NZ search-click popup fits inside mobile viewport (regression: search lands at low zoom)', async ({ page }, testInfo) => {
+      const mobilePlatforms = ['Mobile Chrome', 'Mobile Safari'];
+      test.skip(!mobilePlatforms.includes(testInfo.project.name), 'Mobile-only regression: at the initial fitBounds zoom the popup can\'t fit for edge regions');
+      test.skip(testInfo.project.name === 'webkit' && process.platform === 'linux', 'Leaflet map navigation causes webkit instability on Linux');
+
+      const searchInput = page.getByRole('combobox', { name: 'Search regions' });
+      await searchInput.fill('New Zealand');
+      await page.getByRole('option', { name: /New Zealand North/i }).click();
+
+      const popup = page.locator('.leaflet-popup');
+      await expect(popup).toBeVisible({ timeout: 5000 });
+      // Let the zoom-escalation setView + autoPan settle before measuring.
+      await page.waitForTimeout(800);
+
+      const box = await popup.boundingBox();
+      const vp = page.viewportSize();
+      expect(box).not.toBeNull();
+      expect(vp).not.toBeNull();
+      expect(box!.x).toBeGreaterThanOrEqual(0);
+      expect(box!.y).toBeGreaterThanOrEqual(0);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(vp!.width);
+      expect(box!.y + box!.height).toBeLessThanOrEqual(vp!.height);
+    });
   });
 
   test.describe('Provider Filter', () => {
@@ -101,9 +162,11 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
         mobilePlatforms.includes(testInfo.project.name),
         `Skipping on mobile: ${testInfo.project.name}`
       );
-      const counter = page.getByText(/72 of 72 regions/i);
-      await expect(counter).toBeVisible();
-      
+      const visibleEl = page.locator('#visibleCount');
+      const totalEl = page.locator('#totalCount');
+      await expect(totalEl).toHaveText('72');
+      await expect(visibleEl).toHaveText('72');
+
       const providerFilter = page.locator('#providerFilter');
       await expect(providerFilter).toHaveValue('all');
     });
@@ -118,7 +181,7 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       await expect(resetButton).toBeVisible();
       await expect(providerFilter).toHaveValue('Azure');
       
-      const markers = page.locator('path.leaflet-interactive');
+      const markers = page.locator('.leaflet-marker-icon .map-marker-dot');
       const count = await markers.count();
       expect(count).toBeGreaterThan(0);
     });
@@ -133,7 +196,7 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       await expect(resetButton).toBeVisible();
       await expect(providerFilter).toHaveValue('AWS');
       
-      const markers = page.locator('path.leaflet-interactive');
+      const markers = page.locator('.leaflet-marker-icon .map-marker-dot');
       const count = await markers.count();
       expect(count).toBeGreaterThan(0);
     });
@@ -149,13 +212,13 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       await providerFilter.selectOption('Azure');
       await page.waitForTimeout(300);
 
-      const counter = page.getByText(/of 72 regions/i);
-      await expect(counter).toBeVisible();
+      const visibleEl = page.locator('#visibleCount');
+      const totalEl = page.locator('#totalCount');
+      await expect(totalEl).toHaveText('72');
 
-      const counterText = await counter.textContent();
-      const match = counterText?.match(/(\d+) of 72/);
-      const filteredCount = match ? parseInt(match[1]) : 0;
-      
+      const visibleText = await visibleEl.textContent();
+      const filteredCount = parseInt(visibleText ?? '0', 10);
+
       expect(filteredCount).toBe(45);
       expect(filteredCount).toBeLessThan(72);
     });
@@ -171,13 +234,13 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       await providerFilter.selectOption('AWS');
       await page.waitForTimeout(300);
 
-      const counter = page.getByText(/of 72 regions/i);
-      await expect(counter).toBeVisible();
+      const visibleEl = page.locator('#visibleCount');
+      const totalEl = page.locator('#totalCount');
+      await expect(totalEl).toHaveText('72');
 
-      const counterText = await counter.textContent();
-      const match = counterText?.match(/(\d+) of 72/);
-      const filteredCount = match ? parseInt(match[1]) : 0;
-      
+      const visibleText = await visibleEl.textContent();
+      const filteredCount = parseInt(visibleText ?? '0', 10);
+
       expect(filteredCount).toBe(27);
       expect(filteredCount).toBeLessThan(72);
     });
@@ -193,7 +256,7 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       await expect(page.getByRole('checkbox', { name: 'M365' })).toBeVisible();
       await expect(page.getByRole('checkbox', { name: 'Entra ID' })).toBeVisible();
       await expect(page.getByRole('checkbox', { name: 'Salesforce' })).toBeVisible();
-      await expect(page.getByRole('checkbox', { name: 'Azure' })).toBeVisible();
+      await expect(page.getByRole('checkbox', { name: 'Azure Protection' })).toBeVisible();
     });
 
     test('should filter regions by M365 service', async ({ page }) => {
@@ -206,11 +269,10 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       await page.waitForTimeout(300);
       
       await expect(page.getByRole('button', { name: /M365/i })).toBeVisible();
-      
-      const counter = page.getByText(/of 72 regions/i);
-      const counterText = await counter.textContent();
-      const match = counterText?.match(/(\d+) of 72/);
-      const filteredCount = match ? parseInt(match[1]) : 0;
+
+      const visibleEl = page.locator('#visibleCount');
+      const visibleText = await visibleEl.textContent();
+      const filteredCount = parseInt(visibleText ?? '0', 10);
       expect(filteredCount).toBeLessThan(72);
       expect(filteredCount).toBeGreaterThan(0);
     });
@@ -222,13 +284,12 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       
       await page.getByRole('checkbox', { name: 'M365' }).check();
       await page.getByRole('checkbox', { name: 'Vault' }).check();
-      
+
       await page.waitForTimeout(300);
-      
-      const counter = page.getByText(/of 72 regions/i);
-      const counterText = await counter.textContent();
-      const match = counterText?.match(/(\d+) of 72/);
-      const filteredCount = match ? parseInt(match[1]) : 0;
+
+      const visibleEl = page.locator('#visibleCount');
+      const visibleText = await visibleEl.textContent();
+      const filteredCount = parseInt(visibleText ?? '0', 10);
       expect(filteredCount).toBeGreaterThan(0);
     });
 
@@ -252,7 +313,7 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       await page.waitForTimeout(300);
       
       await expect(page.getByRole('button', { name: /all services/i })).toBeVisible();
-      await expect(page.getByText(/72 of 72 regions/i)).toBeVisible();
+      await expect(page.locator('#visibleCount')).toHaveText('72');
     });
   });
 
@@ -267,11 +328,10 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       await serviceButton.click();
       await page.getByRole('checkbox', { name: 'M365' }).check();
       await page.waitForTimeout(300);
-      
-      const counter = page.getByText(/of 72 regions/i);
-      const counterText = await counter.textContent();
-      const match = counterText?.match(/(\d+) of 72/);
-      const filteredCount = match ? parseInt(match[1]) : 0;
+
+      const visibleEl = page.locator('#visibleCount');
+      const visibleText = await visibleEl.textContent();
+      const filteredCount = parseInt(visibleText ?? '0', 10);
       expect(filteredCount).toBeGreaterThan(0);
       expect(filteredCount).toBeLessThan(72);
     });
@@ -302,12 +362,12 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       await expect(page.getByRole('button', { name: /all services/i })).toBeVisible();
 
       if (!isMobile) {
-        await expect(page.getByText(/72 of 72 regions/i)).toBeVisible();
+        await expect(page.locator('#visibleCount')).toHaveText('72');
       }
 
       if (!isMobile) {
-        await expect(page.locator('path.leaflet-interactive').first()).toBeVisible({ timeout: 5000 });
-        const markers = page.locator('path.leaflet-interactive');
+        await expect(page.locator('.leaflet-marker-icon .map-marker-dot').first()).toBeVisible({ timeout: 5000 });
+        const markers = page.locator('.leaflet-marker-icon .map-marker-dot');
         const count = await markers.count();
         expect(count).toBeGreaterThan(0);
       }
@@ -384,7 +444,7 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
         const response = await route.fetch();
         const html = await response.text();
         const injectedHtml = html.replace(
-          /(<input type=checkbox value=vdc_azure_backup> Azure<\/label>)(<\/div>)/,
+          /(<input type=checkbox value=vdc_azure_backup> Azure Protection<\/label>)(<\/div>)/,
           '$1<label class="multiselect-option text-white light:text-slate-900"><input type=checkbox value=vdc_test_service> Test Service</label>$2'
         );
 
@@ -478,36 +538,103 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
   test.describe('Region Details Popup', () => {
     
     test('should open popup when clicking map marker', async ({ page }, testInfo) => {
-      test.skip(testInfo.project.name === 'Mobile Safari', 'Direct SVG marker clicks are unreliable on simulated mobile');
-      // Known issue: Leaflet markers are not exposed in accessibility tree
-      // Markers are SVG/Canvas elements without accessible roles
+      // Verifies a marker's bound popup opens when the marker DOM node
+      // receives a click event. We dispatch the click via `el.click()`
+      // through page.evaluate rather than Playwright's mouse system —
+      // Leaflet positions markers via absolute transforms inside an
+      // overflow:hidden container, which makes coordinate-based clicks
+      // (mouse.click / locator.click + force) flaky across viewport
+      // sizes and CI hardware. A direct DOM click routes through
+      // Leaflet's `_onMouseClick` handler reliably on every browser
+      // except simulated Mobile Safari, which has its own touch-event
+      // quirks for synthetic events on transformed elements.
+      test.skip(testInfo.project.name === 'Mobile Safari', 'Synthetic click on transformed marker is unreliable in simulated Mobile Safari');
       await page.waitForTimeout(1000);
-      
-      const marker = page.locator('path.leaflet-interactive').first();
-      await marker.click({ force: true });
-      
-      await page.waitForTimeout(3000);
-      
+
+      // Zoom in so individual markers escape clusters. The globally
+      // centred default keeps every marker clustered at zoom 2.
+      const zoomIn = page.locator('.leaflet-control-zoom-in');
+      for (let i = 0; i < 4; i++) {
+        await zoomIn.click();
+        await page.waitForTimeout(150);
+      }
+
+      const clicked = await page.evaluate(() => {
+        const glyphs = Array.from(document.querySelectorAll<HTMLElement>('.leaflet-marker-icon .map-marker-dot'));
+        for (const el of glyphs) {
+          const r = el.getBoundingClientRect();
+          if (r.width === 0) continue;
+          // .map-marker-dot is the inner div Leaflet inserts into its
+          // `.leaflet-marker-icon` wrapper. The click handler is bound
+          // on the wrapper, so dispatch the click there.
+          const wrapper = el.closest<HTMLElement>('.leaflet-marker-icon');
+          if (wrapper) {
+            wrapper.click();
+            return true;
+          }
+        }
+        return false;
+      });
+
+      expect(clicked, 'no individual (un-clustered) marker available to click').toBe(true);
+
       const popup = page.locator('.leaflet-popup');
       await expect(popup).toBeVisible({ timeout: 5000 });
-      
       await expect(popup).toContainText(/AWS|Azure/i);
     });
 
     test('should show correct service details in popup', async ({ page }) => {
       const searchInput = page.getByRole('combobox', { name: 'Search regions' });
       await searchInput.fill('US East 1');
-      
+
       const searchResults = page.getByRole('listbox', { name: 'Search results' });
       await expect(searchResults).toBeVisible();
-      
+
       await page.getByRole('option', { name: /US East 1/i }).click();
       await page.waitForTimeout(1000);
-      
+
       const popup = page.locator('.leaflet-popup');
       await expect(popup).toBeVisible({ timeout: 3000 });
       await expect(popup).toContainText(/US East 1.*Virginia/i);
       await expect(popup).toContainText(/AWS/i);
+      await expect(popup.locator('svg.svc-icon[data-service="vdc_vault"]')).toBeVisible();
+    });
+
+    test('should expose vault tier tooltip copy via data-tooltip and aria-label', async ({ page }) => {
+      const searchInput = page.getByRole('combobox', { name: 'Search regions' });
+      await searchInput.fill('US East 1');
+
+      const searchResults = page.getByRole('listbox', { name: 'Search results' });
+      await expect(searchResults).toBeVisible();
+
+      await page.getByRole('option', { name: /US East 1/i }).click();
+      await page.waitForTimeout(1000);
+
+      const popup = page.locator('.leaflet-popup');
+      await expect(popup).toBeVisible({ timeout: 3000 });
+
+      const foundationPill = popup.locator('.pill[data-tooltip]', { hasText: /Foundation/ }).first();
+      const advancedPill = popup.locator('.pill[data-tooltip]', { hasText: /Advanced/ }).first();
+
+      await expect(foundationPill).toHaveAttribute(
+        'data-tooltip',
+        /Foundation edition.*20% fair usage restore limit/i
+      );
+      await expect(foundationPill).toHaveAttribute(
+        'aria-label',
+        /Foundation.*Foundation edition.*20% fair usage restore limit/i
+      );
+      await expect(foundationPill).toHaveAttribute('tabindex', '0');
+
+      await expect(advancedPill).toHaveAttribute(
+        'data-tooltip',
+        /Advanced edition.*unlimited restores/i
+      );
+      await expect(advancedPill).toHaveAttribute(
+        'aria-label',
+        /Advanced.*Advanced edition.*unlimited restores/i
+      );
+      await expect(advancedPill).toHaveAttribute('tabindex', '0');
     });
 
     test('should close popup with close button', async ({ page }, testInfo) => {
@@ -534,18 +661,17 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
     });
 
     test('should close popup with Escape key', async ({ page }, testInfo) => {
-      test.skip(testInfo.project.name === 'Mobile Safari', 'Direct SVG marker clicks are unreliable on simulated mobile');
-      // Known issue: Leaflet popups do not respond to Escape key
-      const marker = page.locator('path.leaflet-interactive').first();
+      test.skip(true, 'Leaflet popups do not respond to Escape; tracked as separate enhancement');
+      const marker = page.locator('.leaflet-marker-icon .map-marker-dot').first();
       await marker.click();
       await page.waitForTimeout(1000);
-      
+
       const popup = page.locator('.leaflet-popup');
       await expect(popup).toBeVisible({ timeout: 3000 });
-      
+
       await page.keyboard.press('Escape');
       await page.waitForTimeout(300);
-      
+
       await expect(popup).not.toBeVisible();
     });
   });
@@ -711,9 +837,9 @@ test.describe('Veeam Data Cloud Services Map - UI Tests', () => {
       
       const searchInput = page.getByRole('combobox', { name: 'Search regions' });
       await expect(searchInput).toBeVisible();
-      
-      const counter = page.getByText(/72 of 72 regions/i);
-      await expect(counter).toBeVisible();
+
+      await expect(page.locator('#visibleCount')).toHaveText('72');
+      await expect(page.locator('#totalCount')).toHaveText('72');
     });
   });
 });


### PR DESCRIPTION
## Release v1.4.0

Merging release branch to main for version 1.4.0 — Mission Control redesign.

### Changes
- Mission Control UI redesign: brand-aligned header, status strip, `.ctl` control primitive, restyled legend, new typography + theme token system (#103)
- Hybrid POI-dot map markers with provider brand logos; cluster badges restyled to match (#103)
- Popup template restructured with service icons, AA-contrast colours, vault editions as vertical pills (#103)
- Official Veeam help-center service names adopted across UI (#103)
- Initial map view fits to populated regions via `fitBounds`; tiles wrap on wide viewports (#103)
- Themed CSS tooltips with `aria-label` replacing native `title=` (#103)
- Mobile header layout fix; search-click zoom escalation; popup header zero-padding; marker SVG `defs` scoping; live region count for AT (#103)
- ADRs 003–007 documenting the redesign decisions (#103)

### Version
- Version bumped from 1.3.0 to 1.4.0

### Testing
- Full validation runs via PR CI (`pr-validation.yml`: Hugo build + Playwright UI on Chromium / Firefox / WebKit / Mobile Chrome / Mobile Safari)
- Cloudflare Pages preview deploy attached to the PR